### PR TITLE
Fix the yaml example to match the data classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ For our staging environment, we may create a YAML (or Json, etc) file called `ap
 env: staging
 
 database:
-  url: staging.wibble.com
+  host: staging.wibble.com
   port: 3306
   user: theboss
   pass: 0123abcd


### PR DESCRIPTION
The data class `Database` has this property written as `host`, and not `url`. This leads to a compile error:

 ```
Could not instantiate 'org.Config' because:
   - 'database': - Could not instantiate 'org.configs.Database' because:
   - 'host': Missing from config
```