### PR TITLE
Allow for uppercase only env var names

### DIFF
--- a/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/PropertySource.kt
+++ b/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/PropertySource.kt
@@ -22,7 +22,7 @@ interface PropertySource {
 
 fun defaultPropertySources(registry: ParserRegistry): List<PropertySource> =
   listOf(
-    EnvironmentVariablesPropertySource(true, true),
+    EnvironmentVariablesPropertySource(true, false),
     SystemPropertiesPropertySource,
     UserSettingsPropertySource(registry)
   )
@@ -46,7 +46,7 @@ object SystemPropertiesPropertySource : PropertySource {
 }
 
 class EnvironmentVariablesPropertySource(
-  private val useUnderscoresAsSeparator: Boolean, 
+  private val useUnderscoresAsSeparator: Boolean,
   private val allowUppercaseNames: Boolean
 ) : PropertySource {
   override fun node(): ConfigResult<Node> {

--- a/hoplite-json/src/test/kotlin/com/sksamuel/hoplite/json/EnvPropertySourceUppercaseTest.kt
+++ b/hoplite-json/src/test/kotlin/com/sksamuel/hoplite/json/EnvPropertySourceUppercaseTest.kt
@@ -1,0 +1,37 @@
+package com.sksamuel.hoplite.json
+
+import com.sksamuel.hoplite.ConfigLoader
+import com.sksamuel.hoplite.EnvironmentVariablesPropertySource
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.extensions.system.withEnvironment
+import io.kotest.matchers.shouldBe
+
+class EnvPropertySourceUppercaseTest : FunSpec({
+
+  data class Creds(val username: String, val password: String)
+  data class Config(val creds: Creds, val someCamelSetting: String)
+
+  test("loading from envs") {
+    withEnvironment(mapOf("CREDS.USERNAME" to "a", "CREDS.PASSWORD" to "c", "SOME_CAMEL_SETTING" to "c")) {
+      ConfigLoader()
+        .withPropertySource(EnvironmentVariablesPropertySource(true, true))
+        .loadConfigOrThrow<Config>() shouldBe Config(Creds("a", "c"), "c")
+    }
+  }
+
+  test("loading from envs with underscore separator") {
+    withEnvironment(mapOf("CREDS__USERNAME" to "a", "CREDS__PASSWORD" to "b", "SOME_CAMEL_SETTING" to "c")) {
+      ConfigLoader()
+        .withPropertySource(EnvironmentVariablesPropertySource(true, true))
+        .loadConfigOrThrow<Config>() shouldBe Config(Creds("a", "b"), "c")
+    }
+  }
+
+  test("loading from envs with lowercase names") {
+    withEnvironment(mapOf("creds__username" to "a", "creds__password" to "d", "someCamelSetting" to "e")) {
+      ConfigLoader()
+        .withPropertySource(EnvironmentVariablesPropertySource(true, true))
+        .loadConfigOrThrow<Config>() shouldBe Config(Creds("a", "d"), "e")
+    }
+  }
+})


### PR DESCRIPTION
Fix for further case mentioned in #77

As I mentioned in that issue, some shell environments are so restrictive that they only allow uppercase alphanumeric characters as well as underscores, so it would be nice if these environments could be supported by default.

So with `allowUppercaseNames` it checks if each environment starts with an uppercase character before it transforms them. This should then also keep backwards-compatibility. Alternatively, if such conditional transform could be confusing, it would also be possible to have a `enforceUppercaseNames` and throw if environment variables do not start in uppercase. What do you think?