### PR TITLE
Minor fixes to support running on (old) Android environments.

### DIFF
--- a/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/ConfigLoader.kt
+++ b/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/ConfigLoader.kt
@@ -14,6 +14,7 @@ import com.sksamuel.hoplite.parsers.ParserRegistry
 import com.sksamuel.hoplite.parsers.defaultParserRegistry
 import com.sksamuel.hoplite.preprocessor.Preprocessor
 import com.sksamuel.hoplite.preprocessor.defaultPreprocessors
+import java.io.File
 import java.nio.file.Path
 import kotlin.reflect.KClass
 import kotlin.reflect.full.createType
@@ -133,6 +134,36 @@ class ConfigLoader(private val decoderRegistry: DecoderRegistry,
   @JvmName("loadConfigFromPaths")
   inline fun <reified A : Any> loadConfig(paths: List<Path>): ConfigResult<A> {
     return FileSource.fromPaths(paths.toList()).flatMap { loadConfig(A::class, it) }
+  }
+
+  /**
+   * Attempts to load config from the specified Files and returns
+   * an instance of <A> if the values can be appropriately converted.
+   *
+   * This function implements fallback, such that the first resource is scanned first, and the second
+   * resource is scanned if the first does not contain a given path, and so on.
+   */
+  inline fun <reified A : Any> loadConfigOrThrow(vararg files: File): A = loadConfigOrThrow(files.toList())
+
+  @JvmName("loadConfigOrThrowFromFiles")
+  inline fun <reified A : Any> loadConfigOrThrow(files: List<File>): A = loadConfig<A>(files).returnOrThrow()
+
+  @JvmName("loadNodeOrThrowFromFiles")
+  fun loadNodeOrThrow(files: List<File>): Node =
+    FileSource.fromFiles(files.toList()).flatMap { loadNode(it) }.returnOrThrow()
+
+  /**
+   * Attempts to load config from the specified Files and returns
+   * a [ConfigResult] with either the errors during load, or the successfully created instance A.
+   *
+   * This function implements fallback, such that the first resource is scanned first, and the second
+   * resource is scanned if the first does not contain a given path, and so on.
+   */
+  inline fun <reified A : Any> loadConfig(vararg files: File): ConfigResult<A> = loadConfig(files.toList())
+
+  @JvmName("loadConfigFromFiles")
+  inline fun <reified A : Any> loadConfig(files: List<File>): ConfigResult<A> {
+    return FileSource.fromFiles(files.toList()).flatMap { loadConfig(A::class, it) }
   }
 
   @PublishedApi

--- a/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/PropertySource.kt
+++ b/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/PropertySource.kt
@@ -86,19 +86,19 @@ class UserSettingsPropertySource(private val parserRegistry: ParserRegistry) : P
 
 /**
  * An implementation of [PropertySource] that loads values from a file located
- * via a [FileSource]. The file is parsed using an instance of [Parser] retrieved
+ * via a [ConfigSource]. The file is parsed using an instance of [Parser] retrieved
  * from the [ParserRegistry] based on file extension.
  *
  * @param optional if true then if a file is missing, this property source will be skipped. If false, then a missing
  * file will cause the config to fail. Defaults to false.
  */
-class ConfigFilePropertySource(private val file: FileSource,
+class ConfigFilePropertySource(private val config: ConfigSource,
                                private val parserRegistry: ParserRegistry = defaultParserRegistry(),
                                private val optional: Boolean = false) : PropertySource {
   override fun node(): ConfigResult<Node> {
-    val parser = parserRegistry.locate(file.ext())
-    val input = file.open()
-    return Validated.ap(parser, input) { a, b -> a.load(b, file.describe()) }
+    val parser = parserRegistry.locate(config.ext())
+    val input = config.open()
+    return Validated.ap(parser, input) { a, b -> a.load(b, config.describe()) }
       .mapInvalid { ConfigFailure.MultipleFailures(it) }
       .flatMapInvalid { if (optional) Undefined.valid() else it.invalid() }
   }
@@ -106,7 +106,7 @@ class ConfigFilePropertySource(private val file: FileSource,
   companion object {
     fun optionalResource(resource: String,
                          registry: ParserRegistry = defaultParserRegistry()): ConfigFilePropertySource =
-      ConfigFilePropertySource(FileSource.ClasspathSource(resource), registry, true)
+      ConfigFilePropertySource(ConfigSource.ClasspathSource(resource), registry, true)
   }
 }
 

--- a/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/preprocessor/EnvVarPreprocessor.kt
+++ b/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/preprocessor/EnvVarPreprocessor.kt
@@ -5,7 +5,8 @@ import com.sksamuel.hoplite.StringNode
 
 object EnvVarPreprocessor : Preprocessor {
 
-  private val regex = "\\$\\{(.*?)}".toRegex()
+  // Redundant escaping required for Android support.
+  private val regex = "\\$\\{(.*?)\\}".toRegex()
   private val valueWithDefaultRegex = "(.*?):-(.*?)".toRegex()
 
   override fun process(node: Node): Node = when (node) {

--- a/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/preprocessor/PropsPreprocessor.kt
+++ b/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/preprocessor/PropsPreprocessor.kt
@@ -25,7 +25,8 @@ class PropsPreprocessor(private val input: InputStream) : StringNodePreprocessor
     return node.copy(value = value)
   }
 
-  private val regex = "\\$\\{(.*?)}".toRegex()
+  // Redundant escaping required for Android support.
+  private val regex = "\\$\\{(.*?)\\}".toRegex()
 
   private val props = Properties().apply {
     input.use {

--- a/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/preprocessor/RandomPreprocessor.kt
+++ b/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/preprocessor/RandomPreprocessor.kt
@@ -8,6 +8,8 @@ import kotlin.random.Random
 
 private typealias Rule = (String) -> String
 
+// Redundant escaping in this file required for Android support.
+
 object RandomPreprocessor : StringNodePreprocessor() {
 
   private const val a = 33 // '!'
@@ -23,17 +25,17 @@ object RandomPreprocessor : StringNodePreprocessor() {
   }
 
   private val intRule: Rule = {
-    val regex = "\\$\\{random.int}".toRegex()
+    val regex = "\\$\\{random.int\\}".toRegex()
     regex.replace(it) { abs(Random.nextInt()).toString() }
   }
 
   private val booleanRule: Rule = {
-    val regex = "\\$\\{random.boolean}".toRegex()
+    val regex = "\\$\\{random.boolean\\}".toRegex()
     regex.replace(it) { Random.nextBoolean().toString() }
   }
 
   private val intWithMaxRule: Rule = {
-    val regex = "\\$\\{random.int\\(\\s*(\\d+)\\s*\\)}".toRegex()
+    val regex = "\\$\\{random.int\\(\\s*(\\d+)\\s*\\)\\}".toRegex()
     regex.replace(it) { match ->
       val max = match.groupValues[1].toInt()
       Random.nextInt(0, max).toString()
@@ -41,7 +43,7 @@ object RandomPreprocessor : StringNodePreprocessor() {
   }
 
   private val intWithRangeRule: Rule = {
-    val regex = "\\$\\{random.int\\(\\s*(\\d+)\\s*,\\s*(\\d+)\\s*\\)}".toRegex()
+    val regex = "\\$\\{random.int\\(\\s*(\\d+)\\s*,\\s*(\\d+)\\s*\\)\\}".toRegex()
     regex.replace(it) { match ->
       val min = match.groupValues[1].toInt()
       val max = match.groupValues[2].toInt()
@@ -50,17 +52,17 @@ object RandomPreprocessor : StringNodePreprocessor() {
   }
 
   private val longRule: Rule = {
-    val regex = "\\$\\{random.long}".toRegex()
+    val regex = "\\$\\{random.long\\}".toRegex()
     regex.replace(it) { abs(Random.nextLong()).toString() }
   }
 
   private val doubleRule: Rule = {
-    val regex = "\\$\\{random.double}".toRegex()
+    val regex = "\\$\\{random.double\\}".toRegex()
     regex.replace(it) { Random.nextLong().toString() }
   }
 
   private val stringRule: Rule = {
-    val regex = "\\$\\{random.string\\(\\s*(\\d+)\\s*\\)}".toRegex()
+    val regex = "\\$\\{random.string\\(\\s*(\\d+)\\s*\\)\\}".toRegex()
     regex.replace(it) { match ->
       val length = match.groupValues[1].toInt()
       val chars = CharArray(length) { Random.nextInt(a, z).toChar() }
@@ -69,7 +71,7 @@ object RandomPreprocessor : StringNodePreprocessor() {
   }
 
   private val uuidRule: Rule = {
-    val regex = "\\$\\{random.uuid}".toRegex()
+    val regex = "\\$\\{random.uuid\\}".toRegex()
     regex.replace(it) {
       UUID.randomUUID().toString()
     }

--- a/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/preprocessor/SystemPropertyPreprocessor.kt
+++ b/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/preprocessor/SystemPropertyPreprocessor.kt
@@ -15,7 +15,8 @@ abstract class StringNodePreprocessor : Preprocessor {
 
 object SystemPropertyPreprocessor : StringNodePreprocessor() {
 
-  private val regex = "\\$\\{(.*?)}".toRegex()
+  // Redundant escaping required for Android support.
+  private val regex = "\\$\\{(.*?)\\}".toRegex()
 
   override fun map(node: StringNode): Node {
     val value = regex.replace(node.value) {

--- a/hoplite-core/src/main/resources/META-INF/services/com.sksamuel.hoplite.decoder.Decoder
+++ b/hoplite-core/src/main/resources/META-INF/services/com.sksamuel.hoplite.decoder.Decoder
@@ -1,6 +1,3 @@
-com.sksamuel.hoplite.decoder.KerberosPrincipalDecoder
-com.sksamuel.hoplite.decoder.JMXPrincipalDecoder
-com.sksamuel.hoplite.decoder.X500PrincipalDecoder
 com.sksamuel.hoplite.decoder.UUIDDecoder
 com.sksamuel.hoplite.decoder.LocalDateDecoder
 com.sksamuel.hoplite.decoder.LocalDateTimeDecoder

--- a/hoplite-javax/build.gradle
+++ b/hoplite-javax/build.gradle
@@ -1,0 +1,22 @@
+buildscript {
+    ext.awsVersion = "1.11.708"
+}
+
+plugins {
+    id 'org.jetbrains.kotlin.jvm'
+}
+
+dependencies {
+    api project(":hoplite-core")
+    testImplementation project(":hoplite-toml")
+    testImplementation project(":hoplite-yaml")
+    testImplementation project(":hoplite-json")
+}
+
+tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
+    kotlinOptions {
+        jvmTarget = "1.8"
+    }
+}
+
+apply from: '../publish.gradle'

--- a/hoplite-javax/src/main/kotlin/com/sksamuel/hoplite/decoder/javax/security.kt
+++ b/hoplite-javax/src/main/kotlin/com/sksamuel/hoplite/decoder/javax/security.kt
@@ -1,4 +1,4 @@
-package com.sksamuel.hoplite.decoder
+package com.sksamuel.hoplite.decoder.javax
 
 import com.sksamuel.hoplite.fp.invalid
 import com.sksamuel.hoplite.fp.valid
@@ -7,6 +7,7 @@ import com.sksamuel.hoplite.ConfigResult
 import com.sksamuel.hoplite.DecoderContext
 import com.sksamuel.hoplite.StringNode
 import com.sksamuel.hoplite.Node
+import com.sksamuel.hoplite.decoder.NullHandlingDecoder
 import javax.management.remote.JMXPrincipal
 import javax.security.auth.kerberos.KerberosPrincipal
 import javax.security.auth.x500.X500Principal

--- a/hoplite-javax/src/main/resources/META-INF/services/com.sksamuel.hoplite.decoder.Decoder
+++ b/hoplite-javax/src/main/resources/META-INF/services/com.sksamuel.hoplite.decoder.Decoder
@@ -1,0 +1,3 @@
+com.sksamuel.hoplite.decoder.javax.KerberosPrincipalDecoder
+com.sksamuel.hoplite.decoder.javax.JMXPrincipalDecoder
+com.sksamuel.hoplite.decoder.javax.X500PrincipalDecoder

--- a/settings.gradle
+++ b/settings.gradle
@@ -5,6 +5,7 @@ include 'hoplite-core',
         'hoplite-hdfs',
         'hoplite-hocon',
         'hoplite-ktor',
+        'hoplite-javax',
         'hoplite-json',
         'hoplite-toml',
         'hoplite-yaml'


### PR DESCRIPTION
Fixes #108 

  * Android has a custom Regex parser which is not compliant. It needs the closing brace to be escaped as well for variable substitution preprocessors. Shouldn't hurt other platforms, though, only emit warnings about unnecessary escaping.
  * "Unsealed" FileSource so it can be extended externally (required for Android to be able to read from assets).
  * Added "FileIoSource" FileSource implementation that does not use APIs only available in Android Oreo (Files and Path).
  * Moved Decoders for javax APIs to new module that can be excluded for platforms that don't have javax (guess which one).