### PR TITLE
Replaced Map.getOrDefault since it doesn't exist in Android API 19.

### DIFF
--- a/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/nodes.kt
+++ b/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/nodes.kt
@@ -72,7 +72,7 @@ data class MapNode(val map: Map<String, Node>,
                    override val pos: Pos,
                    val value: Node = Undefined) : ContainerNode() {
   override val simpleName: String = "Map"
-  override fun atKey(key: String): Node = map.getOrDefault(key, Undefined)
+  override fun atKey(key: String): Node = map[key] ?: Undefined
   override fun atIndex(index: Int): Node = Undefined
   override val size: Int = map.size
 }


### PR DESCRIPTION
Android developers like to only supply partial implementations of Java. getOrDefault is one of those, only available in Android API 26 or later. :(

Pretty sure this should be equivalent, even if perhaps not as pretty.