### PR TITLE
Default registries with provided class loader

### DIFF
--- a/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/ConfigLoader.kt
+++ b/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/ConfigLoader.kt
@@ -166,7 +166,9 @@ class ConfigLoader constructor(
     fun build(): ConfigLoader {
       // build the DefaultDecoderRegistry
       val decoderRegistry = defaultDecoderRegistry(this.classLoader)
-      this.decoderStaging.forEach(decoderRegistry::register)
+      this.decoderStaging.forEach {
+          decoder: Decoder<*> -> decoderRegistry.register(decoder)
+      }
 
       // build the DefaultParserRegistry
       val parserRegistry = defaultParserRegistry(this.classLoader)

--- a/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/ConfigLoader.kt
+++ b/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/ConfigLoader.kt
@@ -178,7 +178,7 @@ class ConfigLoader constructor(
       }
 
       // other defaults
-      val propertySources = defaultPropertySources(parserRegistry)
+      val propertySources = defaultPropertySources(parserRegistry) + this.propertySourceStaging
       val preprocessors = defaultPreprocessors() + this.preprocessorStaging
       val paramMappers = defaultParamMappers() + this.paramMapperStaging
 

--- a/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/ConfigLoader.kt
+++ b/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/ConfigLoader.kt
@@ -17,7 +17,7 @@ import kotlin.reflect.full.createType
 
 class ConfigException(msg: String) : java.lang.RuntimeException(msg)
 
-class ConfigLoader private constructor(
+class ConfigLoader constructor(
   private val decoderRegistry: DecoderRegistry,
   private val propertySources: List<PropertySource>,
   private val parserRegistry: ParserRegistry,

--- a/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/ConfigLoader.kt
+++ b/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/ConfigLoader.kt
@@ -165,17 +165,15 @@ class ConfigLoader private constructor(
 
     fun build(): ConfigLoader {
       // build the DefaultDecoderRegistry
-      val decoderRegistry = defaultDecoderRegistry(this.classLoader).apply {
-        this@Builder.decoderStaging.forEach(this::register)
-      }
+      val decoderRegistry = defaultDecoderRegistry(this.classLoader)
+      this.decoderStaging.forEach(decoderRegistry::register)
 
       // build the DefaultParserRegistry
-      val parserRegistry = defaultParserRegistry(this.classLoader).apply {
-        this@Builder.parserStaging.forEach {
+      val parserRegistry = defaultParserRegistry(this.classLoader)
+        this.parserStaging.forEach {
           val (ext, parser) = it
-          this.register(ext, parser)
+          parserRegistry.register(ext, parser)
         }
-      }
 
       // other defaults
       val propertySources = defaultPropertySources(parserRegistry)

--- a/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/ConfigLoader.kt
+++ b/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/ConfigLoader.kt
@@ -170,10 +170,10 @@ class ConfigLoader private constructor(
 
       // build the DefaultParserRegistry
       val parserRegistry = defaultParserRegistry(this.classLoader)
-        this.parserStaging.forEach {
-          val (ext, parser) = it
-          parserRegistry.register(ext, parser)
-        }
+      this.parserStaging.forEach {
+        val (ext, parser) = it
+        parserRegistry.register(ext, parser)
+      }
 
       // other defaults
       val propertySources = defaultPropertySources(parserRegistry)

--- a/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/decoder/DecoderRegistry.kt
+++ b/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/decoder/DecoderRegistry.kt
@@ -56,5 +56,9 @@ class DefaultDecoderRegistry(private val decoders: List<Decoder<*>>) : DecoderRe
 }
 
 fun defaultDecoderRegistry(): DecoderRegistry {
-  return ServiceLoader.load(Decoder::class.java).toList().let { DefaultDecoderRegistry(it) }
+  return defaultDecoderRegistry(Thread.currentThread().contextClassLoader)
+}
+
+fun defaultDecoderRegistry(classLoader: ClassLoader): DecoderRegistry {
+  return ServiceLoader.load(Decoder::class.java, classLoader).toList().let { DefaultDecoderRegistry(it) }
 }

--- a/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/parsers/Parser.kt
+++ b/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/parsers/Parser.kt
@@ -42,7 +42,11 @@ class DefaultParserRegistry(private val map: Map<String, Parser>) : ParserRegist
 }
 
 fun defaultParserRegistry(): ParserRegistry {
-  return ServiceLoader.load(Parser::class.java).toList()
+  return defaultParserRegistry(Thread.currentThread().contextClassLoader)
+}
+
+fun defaultParserRegistry(classLoader: ClassLoader): ParserRegistry {
+  return ServiceLoader.load(Parser::class.java, classLoader).toList()
     .fold(ParserRegistry.zero) { registry, parser ->
       parser.defaultFileExtensions().fold(registry) { r, ext -> r.register(ext, parser) }
     }


### PR DESCRIPTION
Add a function for loading the default Decoder and Parser registries using a provided ClassLoader. Delegate the original no-arg function to this new function with the same default value loaded by ServiceLoader under the hood. Closes #142 

The intent is to instantiate a `ConfigLoader` like so:
```kotlin
val decoders = defaultDecoderRegistry(parentClassLoader)
val parsers = defaultParserRegistry(parentClassLoader)
val propertySources = defaultPropertySources(parsers)

// defaultPreprocessors() and defaultParamMappers() are the original functions
val loader = ConfigLoader(decoders, propertySources, parsers, defaultPreprocessors(), defaultParamMappers())
```

I implemented this with overloaded functions, but adding a default value parameter to the original function definitions would work just as well. 

A more generic approach could be
```kotlin
interface Provider<T> {
    fun get(): T
}

fun defaultDecoderRegistry(classLoaderProvider: Provider<ClassLoader>): DecoderRegistry {
    return ServiceLoader.load(Decoder::class.java, classLoaderProvider.get()).toList().let { DefaultDecoderRegistry(it) }
}

// analogously for defaultParserRegistry
```