### PR TITLE
prevent to log the config especially with credentials

### DIFF
--- a/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/parsers/loadProps.kt
+++ b/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/parsers/loadProps.kt
@@ -39,7 +39,5 @@ fun Properties.toNode(source: String): Node {
     }
   }
 
-  val node = root.toNode()
-  println(node.toString())
-  return node
+  return root.toNode()
 }


### PR DESCRIPTION
Hey, I saw in the logs that the config is logged and especially the credentials are not masked due to the toString() call.
This PR should prevent this.