### PR TITLE
Implement an abstract PrefixProcessor

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,7 +331,8 @@ perform database lookups, or whatever other custom action you need when the conf
 
 You can add custom pre-processors in addition to the built in ones, by using the function `withPreprocessor` on the `ConfigLoader` class, and passing in an instance of the `Preprocessor` interface.
 A typical use case of a custom preprocessor is to lookup some values in a database, or from a third party secrets store such as [Vault](https://www.vaultproject.io/) or [Amazon Parameter Store](https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-parameter-store.html).
-One way this can be implemented is to have a prefix, and then use a preprocessor to look for the prefix in strings, and if the prefix is present, use the rest of the string as a key to the service.
+
+One way this can be implemented is to have a prefix, and then use a preprocessor to look for the prefix in strings, and if the prefix is present, use the rest of the string as a key to the service. The `PrefixProcessor` abstract class implements this by handling the node traversal, while leaving the specific processing as an exercise for the reader.
 
 For example
 

--- a/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/preprocessor/Preprocessor.kt
+++ b/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/preprocessor/Preprocessor.kt
@@ -47,13 +47,21 @@ fun defaultPreprocessors() = listOf(
   LookupPreprocessor
 )
 
-abstract class PrefixProcessor(private val prefix: String) : Preprocessor {
+/**
+ * Process property strings that start with a given prefix. When specifying the prefix, include any punctuation
+ * separating it from the actual value. The entire prefix, including any punctuation, will be stripped off before
+ * the value is sent to the [processString] method.
+ */
+abstract class PrefixProcessor(private val prefix: String) : TraversingPrimitivePreprocessor() {
 
-  abstract fun handle(node: StringNode): Node
+  abstract fun processString(valueWithoutPrefix: String): String
 
-  override fun process(node: Node): Node = when (node) {
-    is StringNode -> if (node.value.startsWith(prefix)) handle(node) else node
-    else -> node
+  override fun handle(node: PrimitiveNode): Node {
+    return if (node is StringNode && node.value.startsWith(prefix)) {
+      node.copy(value = processString(node.value.substring(prefix.length)))
+    } else {
+      node
+    }
   }
 }
 

--- a/hoplite-core/src/test/kotlin/com/sksamuel/hoplite/preprocessor/PrefixProcessorTest.kt
+++ b/hoplite-core/src/test/kotlin/com/sksamuel/hoplite/preprocessor/PrefixProcessorTest.kt
@@ -1,0 +1,25 @@
+package com.sksamuel.hoplite.preprocessor
+
+import com.sksamuel.hoplite.ConfigLoader
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+
+private object Upcaser : PrefixProcessor("upcase:") {
+  override fun processString(valueWithoutPrefix: String): String = valueWithoutPrefix.toUpperCase()
+}
+
+class PrefixProcessorTest : StringSpec() {
+  init {
+    "should process string nodes with a prefix" {
+
+      data class Config(val a: String, val b: String)
+
+      val config = ConfigLoader.Builder()
+        .addPreprocessor(Upcaser)
+        .build()
+        .loadConfigOrThrow<Config>("/prefixProcessor.props")
+
+      config shouldBe Config(a = "This is the quiet part", b = "YOU KIDS GET OFF MY LAWN")
+    }
+  }
+}

--- a/hoplite-core/src/test/resources/prefixProcessor.props
+++ b/hoplite-core/src/test/resources/prefixProcessor.props
@@ -1,0 +1,2 @@
+a=This is the quiet part
+b=upcase:You kids get off my lawn


### PR DESCRIPTION
The existing PrefixProcessor doesn't traverse the node tree, so
it never actually sees any StringNodes. By basing it off of the
TraversingPrimitivePreprocessor class, it sees the individual
nodes, and processes the ones with a specified prefix.