### PR TITLE
Fix parser registry for custom mappings

### DIFF
--- a/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/ConfigLoader.kt
+++ b/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/ConfigLoader.kt
@@ -172,8 +172,10 @@ class ConfigLoader constructor(
         registry.register(decoder)
       }
 
-      // build the DefaultParserRegistry, first from the classloader, then any custom mappings
-      val parserRegistry = defaultParserRegistry(this.classLoader).register(this.parserStaging);
+      // build the DefaultParserRegistry
+      val parserRegistry = this.parserStaging.asSequence().fold(defaultParserRegistry(this.classLoader)) {
+        registry, (ext, parser) -> registry.register(ext, parser);
+      }
 
       // other defaults
       val propertySources = defaultPropertySources(parserRegistry) + this.propertySourceStaging

--- a/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/ConfigLoader.kt
+++ b/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/ConfigLoader.kt
@@ -172,12 +172,8 @@ class ConfigLoader constructor(
         registry.register(decoder)
       }
 
-      // build the DefaultParserRegistry
-      val parserRegistry = defaultParserRegistry(this.classLoader)
-      this.parserStaging.forEach {
-        val (ext, parser) = it
-        parserRegistry.register(ext, parser)
-      }
+      // build the DefaultParserRegistry, first from the classloader, then any custom mappings
+      val parserRegistry = defaultParserRegistry(this.classLoader).register(this.parserStaging);
 
       // other defaults
       val propertySources = defaultPropertySources(parserRegistry) + this.propertySourceStaging

--- a/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/parsers/Parser.kt
+++ b/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/parsers/Parser.kt
@@ -19,6 +19,8 @@ interface ParserRegistry {
 
   fun register(ext: String, parser: Parser): ParserRegistry
 
+  fun register(parserMap: Map<String, Parser>): ParserRegistry
+
   /**
    * Returns the currently supported file mappings
    */
@@ -39,6 +41,10 @@ class DefaultParserRegistry(private val map: Map<String, Parser>) : ParserRegist
 
   override fun register(ext: String, parser: Parser): ParserRegistry = DefaultParserRegistry(
     map.plus(ext to parser))
+
+  override fun register(parserMap: Map<String, Parser>): ParserRegistry = DefaultParserRegistry(
+    this.map.plus(parserMap)
+  )
 }
 
 fun defaultParserRegistry(): ParserRegistry {

--- a/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/parsers/Parser.kt
+++ b/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/parsers/Parser.kt
@@ -19,8 +19,6 @@ interface ParserRegistry {
 
   fun register(ext: String, parser: Parser): ParserRegistry
 
-  fun register(parserMap: Map<String, Parser>): ParserRegistry
-
   /**
    * Returns the currently supported file mappings
    */
@@ -41,10 +39,6 @@ class DefaultParserRegistry(private val map: Map<String, Parser>) : ParserRegist
 
   override fun register(ext: String, parser: Parser): ParserRegistry = DefaultParserRegistry(
     map.plus(ext to parser))
-
-  override fun register(parserMap: Map<String, Parser>): ParserRegistry = DefaultParserRegistry(
-    this.map.plus(parserMap)
-  )
 }
 
 fun defaultParserRegistry(): ParserRegistry {


### PR DESCRIPTION
As first mentioned in #157 by @AvlWx2014 and @smcbn, ParserRegistry suffers the same issue as DecodeRegistry did, and unfortunately I think it was missed at the time.

I added an additional function to register a map of extension/parser key values, making this particular line 176 in ConfigLoader's build() straightforward. However, I'm not at all opposed to both the solution proposed by @AvlWx2014 to expose the current map of parsers, or just making the parserRegistry a var and reassigning it repeatedly.

@sksamuel Let me know if you prefer another way to fix this bug - and thanks for the great library!