### PR TITLE
Add convenience methods for stream and string PropertySource

### DIFF
--- a/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/PropertySource.kt
+++ b/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/PropertySource.kt
@@ -8,6 +8,7 @@ import com.sksamuel.hoplite.parsers.Parser
 import com.sksamuel.hoplite.parsers.ParserRegistry
 import com.sksamuel.hoplite.parsers.defaultParserRegistry
 import com.sksamuel.hoplite.parsers.toNode
+import java.io.ByteArrayInputStream
 import java.io.File
 import java.io.InputStream
 import java.nio.file.Path
@@ -46,6 +47,25 @@ interface PropertySource {
      */
     fun path(path: Path, optional: Boolean = false) =
       ConfigFilePropertySource(ConfigSource.PathSource(path), optional = optional)
+
+    /**
+     * Returns a [PropertySource] that will read the specified input stream.
+     *
+     * @param input the input stream to read from
+     * @param ext the file extension of the input format
+     */
+    fun stream(input: InputStream, ext: String) =
+      InputStreamPropertySource(input, ext)
+
+    /**
+     * Returns a [PropertySource] that will read from the specified string.
+     *
+     * @param str the string to read from
+     * @param ext the file extension of the input format
+     */
+    fun string(str: String, ext: String) =
+      stream(str.byteInputStream(), ext)
+
   }
 }
 

--- a/hoplite-core/src/test/kotlin/com/sksamuel/hoplite/PropertySourceTest.kt
+++ b/hoplite-core/src/test/kotlin/com/sksamuel/hoplite/PropertySourceTest.kt
@@ -1,0 +1,39 @@
+package com.sksamuel.hoplite
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+class PropertySourceTest : FunSpec() {
+  init {
+
+    test("reads config from string") {
+      data class TestConfig(val a: String, val b: Int)
+      val config = ConfigLoader.Builder()
+        .addPropertySource(PropertySource.string("""
+          a = A value
+          b = 42
+          """.trimIndent(), "props"))
+        .build()
+        .loadConfigOrThrow<TestConfig>()
+
+      config shouldBe TestConfig("A value", 42)
+    }
+
+    test("reads config from input stream") {
+      data class TestConfig(val a: String, val b: Int)
+
+      val stream = """
+          a = A value
+          b = 42
+          """.trimIndent().byteInputStream(Charsets.UTF_8)
+
+      val config = ConfigLoader.Builder()
+        .addPropertySource(PropertySource.stream(stream, "props"))
+        .build()
+        .loadConfigOrThrow<TestConfig>()
+
+      config shouldBe TestConfig("A value", 42)
+    }
+
+  }
+}


### PR DESCRIPTION
In my tests I often use string-based configurations.

This PR adds the `PropertySource.stream()` and `PropertySource.string()` convenience methods,
and a test for each.