### PR TITLE
Add support for objects in sealed classes

### DIFF
--- a/hoplite-yaml/src/test/resources/sealed_class_with_list_of_objects.yaml
+++ b/hoplite-yaml/src/test/resources/sealed_class_with_list_of_objects.yaml
@@ -1,0 +1,2 @@
+poolingStrategy:
+  combo: [Omni, OsVersion]

--- a/hoplite-yaml/src/test/resources/sealed_class_with_object.yaml
+++ b/hoplite-yaml/src/test/resources/sealed_class_with_object.yaml
@@ -1,0 +1,1 @@
+poolingStrategy: OsVersion

--- a/hoplite-yaml/src/test/resources/sealed_class_with_object_invalid_value.yaml
+++ b/hoplite-yaml/src/test/resources/sealed_class_with_object_invalid_value.yaml
@@ -1,0 +1,1 @@
+poolingStrategy: Random


### PR DESCRIPTION
Hello, 
In our project we use combination of objects and data classes inside sealed classes to store some info as a type.
For example
```
sealed class PoolingStrategy {
    object Omni : PoolingStrategy()
    object ABI : PoolingStrategy()
    data class Combo(val list: List<PoolingStrategy>) : PoolingStrategy()
    object Manufacturer : PoolingStrategy()
    object Model : PoolingStrategy()
    object OperatingSystem : PoolingStrategy()
}
```
Only one data class inside and multiple objects, but objects were not supported.
This pull request adds support for objects inside sealed classes
