### PR TITLE
Add ISO-8601 Duration support

### DIFF
--- a/hoplite-yaml/src/test/kotlin/com/sksamuel/hoplite/yaml/BasicDecodersTest.kt
+++ b/hoplite-yaml/src/test/kotlin/com/sksamuel/hoplite/yaml/BasicDecodersTest.kt
@@ -52,6 +52,15 @@ class BasicTypesTest : FunSpec({
       )
   }
 
+  test("Duration in ISO-8601 format") {
+    data class Test(val pushTimeout: Duration, val pullTimeout: Duration)
+    val config = ConfigLoader().loadConfigOrThrow<Test>("/test_duration_iso_8601.yml")
+    config shouldBe Test(
+      Duration.ofSeconds(30),
+      Duration.ofHours(1),
+    )
+  }
+
   test("kotlin.Enum") {
     data class Test(val wine: Wine)
 

--- a/hoplite-yaml/src/test/resources/test_duration_iso_8601.yml
+++ b/hoplite-yaml/src/test/resources/test_duration_iso_8601.yml
@@ -1,0 +1,2 @@
+pushTimeout: "PT30S"
+pullTimeout: "PT1H"


### PR DESCRIPTION
java.time.Duration supports ISO-8601 duration format with Duration.parse() https://docs.oracle.com/javase/8/docs/api/java/time/Duration.html#parse-java.lang.CharSequence-
This PR adds support for this feature