### PR TITLE
Add missing `ConfligLoader.loadConfigOrThrow` overload

### DIFF
--- a/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/ConfigLoader.kt
+++ b/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/ConfigLoader.kt
@@ -300,6 +300,9 @@ class ConfigLoader constructor(
   @JvmName("loadConfigOrThrowFromFiles")
   inline fun <reified A : Any> loadConfigOrThrow(files: List<File>): A = loadConfig<A>(files).returnOrThrow()
 
+  fun <A : Any> loadConfigOrThrow(klass: KClass<A>, inputs: List<ConfigSource>): A =
+    loadConfig(klass, inputs).returnOrThrow()
+
   @JvmName("loadNodeOrThrowFromFiles")
   fun loadNodeOrThrow(files: List<File>): Node =
     ConfigSource.fromFiles(files.toList()).flatMap { loadNode(it) }.returnOrThrow()


### PR DESCRIPTION
I want to call `loadConfigOrThrow` from a generic context in which type variable `A` is _not_ reified. In this case, I can call the `loadConfig(KClass<A>, List<ConfigSource>)` overload, but to copy the functionality of `loadConfigOrThrow` I would need to also be able to call the `returnOrThrow()` method, which is internal.

Instead, this PR adds an overload to `loadConfigOrThrow(KClass<A>, List<ConfigSource>)`, such that both `loadConfig` and `loadConfigOrThrow` have the same overloads.