### PR TITLE
Update PropertySource.kt

### DIFF
--- a/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/PropertySource.kt
+++ b/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/PropertySource.kt
@@ -295,19 +295,22 @@ class ConfigFilePropertySource(
  * file will cause the config to fail. Defaults to false.
  */
 class ExternalFilePropertySource(
-  private val filepath: String,
-  private val optional: Boolean = false
+    // for external files not on the classpath
+    private val filepath: String,
+    private val optional: Boolean = false
 ) : PropertySource {
 
-  // same as ConfigFilePropertySource, but first we validate file exists
-  override fun node(context: PropertySourceContext): ConfigResult<Node> {
-    if (!File(filepath).exists() && !optional)
-      throw Exception("specified external config file ($filepath) doesn't exist")
-    val configFile = File(filepath)
-    
-    // following example of UserSettingsPropertySource 
-    val parser = context.parsers.locate(configFile.extension())
-    val input = configFile.inputStream()
-    return parser.load(input, parser.toString()) // or is it filepath.toString() ?
-  }
+    // first we validate if file exists
+    override fun node(context: PropertySourceContext): ConfigResult<Node> {
+        return if (!File(filepath).exists()) {
+            if (optional) Undefined.valid()
+                else ConfigFailure.UnknownSource(filepath).invalid()
+        } else {
+            File(filepath).let { configFile ->
+                context.parsers.locate(configFile.extension).map {
+                    it.load(configFile.inputStream(), filepath)
+                }
+            }
+        }
+    }
 }

--- a/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/PropertySource.kt
+++ b/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/PropertySource.kt
@@ -288,3 +288,26 @@ class ConfigFilePropertySource(
   }
 }
 
+/**
+ * An implementation of [PropertySource] that loads values from a file outside the classpath.
+ *
+ * @param optional if true then if a file is missing, this property source will be skipped. If false, then a missing
+ * file will cause the config to fail. Defaults to false.
+ */
+class ExternalFilePropertySource(
+  private val filepath: String,
+  private val optional: Boolean = false
+) : PropertySource {
+
+  // same as ConfigFilePropertySource, but first we validate file exists
+  override fun node(context: PropertySourceContext): ConfigResult<Node> {
+    if (!File(filepath).exists() && !optional)
+      throw Exception("specified external config file ($filepath) doesn't exist")
+    val configFile = File(filepath)
+    
+    // following example of UserSettingsPropertySource 
+    val parser = context.parsers.locate(configFile.extension())
+    val input = configFile.inputStream()
+    return parser.load(input, parser.toString()) // or is it filepath.toString() ?
+  }
+}


### PR DESCRIPTION
This is a response to [this comment](https://github.com/sksamuel/hoplite/issues/161#issuecomment-677468140) which suggests you can refer to a file source by name (string). In fact, `FileSource` only accepts a `File` object, which complicates things because if the file doesn't exist, `File(<non-existent file>)` will throw an error independently, even when we set the parameter `optional = true`. Instead of failing gracefully (i.e. skipping the non-existent file and looking for another property source), it will always throw an error when the file is missing.  (see [line 27 here](https://github.com/sksamuel/hoplite/blob/master/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/ConfigSource.kt) .)