### PR TITLE
Added order to defaults (Sources, Preprocessors and ParamMappers)

### DIFF
--- a/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/ConfigLoader.kt
+++ b/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/ConfigLoader.kt
@@ -114,20 +114,20 @@ class ConfigLoader constructor(
     private val paramMapperStaging = mutableListOf<ParameterMapper>()
     private val failureCallbacks = mutableListOf<(Throwable) -> Unit>()
     private var mode: DecodeMode = DecodeMode.Lenient
-    private var defaultSources: DefaultOrder? = null
-    private var defaultPreprocessors: DefaultOrder? = null
-    private var defaultParamMappers: DefaultOrder? = null
+    private var defaultSources = true
+    private var defaultPreprocessors = true
+    private var defaultParamMappers = true
 
-    fun withDefaultSources(defaultOrder: DefaultOrder?): Builder = apply {
-      this.defaultSources = defaultOrder
+    fun withDefaultSources(defaultSources: Boolean): Builder = apply {
+      this.defaultSources = defaultSources
     }
 
-    fun withDefaultPreprocessors(defaultOrder: DefaultOrder?): Builder = apply {
-      this.defaultPreprocessors = defaultOrder
+    fun withDefaultPreprocessors(defaultPreprocessors: Boolean): Builder = apply {
+      this.defaultPreprocessors = defaultPreprocessors
     }
 
-    fun withDefaultParamMappers(defaultOrder: DefaultOrder?): Builder = apply {
-      this.defaultParamMappers = defaultOrder
+    fun withDefaultParamMappers(defaultParamMappers: Boolean): Builder = apply {
+      this.defaultParamMappers = defaultParamMappers
     }
 
     fun withClassLoader(classLoader: ClassLoader): Builder = apply {
@@ -212,22 +212,19 @@ class ConfigLoader constructor(
         }
 
       // other defaults
-      val propertySources = when (defaultSources) {
-        DefaultOrder.Before -> defaultPropertySources() + this.propertySourceStaging
-        DefaultOrder.After -> this.propertySourceStaging + defaultPropertySources()
-        null -> this.propertySourceStaging
+      val propertySources = when {
+        defaultSources -> defaultPropertySources() + this.propertySourceStaging
+        else -> this.propertySourceStaging
       }
 
-      val preprocessors = when (defaultPreprocessors) {
-        DefaultOrder.Before -> defaultPreprocessors() + this.preprocessorStaging
-        DefaultOrder.After -> this.preprocessorStaging + defaultPreprocessors()
-        null -> this.preprocessorStaging
+      val preprocessors = when {
+        defaultPreprocessors -> defaultPreprocessors() + this.preprocessorStaging
+        else -> this.preprocessorStaging
       }
 
-      val paramMappers = when (defaultParamMappers) {
-        DefaultOrder.Before -> defaultParamMappers() + this.paramMapperStaging
-        DefaultOrder.After -> this.paramMapperStaging + defaultParamMappers()
-        null -> this.paramMapperStaging
+      val paramMappers = when {
+        defaultParamMappers -> defaultParamMappers() + this.paramMapperStaging
+        else -> this.paramMapperStaging
       }
 
       return ConfigLoader(
@@ -382,10 +379,6 @@ class ConfigLoader constructor(
         val multipleFailures = ConfigFailure.MultipleFailures(it)
         multipleFailures
       }
-  }
-
-  enum class DefaultOrder {
-    Before, After
   }
 }
 

--- a/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/ConfigLoader.kt
+++ b/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/ConfigLoader.kt
@@ -118,14 +118,23 @@ class ConfigLoader constructor(
     private var defaultPreprocessors = true
     private var defaultParamMappers = true
 
+    /**
+     * Adds before the specified ones
+     */
     fun withDefaultSources(defaultSources: Boolean): Builder = apply {
       this.defaultSources = defaultSources
     }
 
+    /**
+     * Adds before the specified ones
+     */
     fun withDefaultPreprocessors(defaultPreprocessors: Boolean): Builder = apply {
       this.defaultPreprocessors = defaultPreprocessors
     }
 
+    /**
+     * Adds before the specified ones
+     */
     fun withDefaultParamMappers(defaultParamMappers: Boolean): Builder = apply {
       this.defaultParamMappers = defaultParamMappers
     }
@@ -167,8 +176,20 @@ class ConfigLoader constructor(
 
     fun addSources(sources: Iterable<PropertySource>) = addPropertySources(sources)
 
+    fun addDefaultSources(): Builder {
+      withDefaultSources(false)
+
+      return addPropertySources(defaultPropertySources())
+    }
+
     fun addPropertySources(propertySources: Iterable<PropertySource>): Builder = apply {
       this.propertySourceStaging.addAll(propertySources)
+    }
+
+    fun addDefaultPropertySources(): Builder {
+      withDefaultSources(false)
+
+      return addPropertySources(defaultPropertySources())
     }
 
     fun addPreprocessor(preprocessor: Preprocessor): Builder = apply {
@@ -179,12 +200,24 @@ class ConfigLoader constructor(
       this.preprocessorStaging.addAll(preprocessors)
     }
 
+    fun addDefaultPreprocessors(): Builder {
+      withDefaultPreprocessors(false)
+
+      return addPreprocessors(defaultPreprocessors())
+    }
+
     fun addParameterMapper(paramMapper: ParameterMapper): Builder = apply {
       this.paramMapperStaging.add(paramMapper)
     }
 
     fun addParameterMappers(paramMappers: Iterable<ParameterMapper>): Builder = apply {
       this.paramMapperStaging.addAll(paramMappers)
+    }
+
+    fun addDefaultParameterMappers(): Builder {
+      withDefaultParamMappers(false)
+
+      return addParameterMappers(defaultParamMappers())
     }
 
     /**

--- a/hoplite-core/src/test/kotlin/com/sksamuel/hoplite/WithoutDefaultsRegistryTest.kt
+++ b/hoplite-core/src/test/kotlin/com/sksamuel/hoplite/WithoutDefaultsRegistryTest.kt
@@ -19,7 +19,7 @@ class WithoutDefaultsRegistryTest : FunSpec() {
 
     test("empty sources registry throws error") {
       val loader = ConfigLoader {
-        withDefaultSources(null)
+        withDefaultSources(false)
         addMapSource(mapOf("custom_value" to "\${PATH}"))
       }
       val e = loader.loadConfig<Config>()
@@ -29,7 +29,7 @@ class WithoutDefaultsRegistryTest : FunSpec() {
 
     test("empty param mappers registry throws error") {
       val loader = ConfigLoader {
-        withDefaultParamMappers(null)
+        withDefaultParamMappers(false)
         addMapSource(mapOf("custom_value" to "\${PATH}"))
       }
 
@@ -40,7 +40,7 @@ class WithoutDefaultsRegistryTest : FunSpec() {
 
     test("empty preprocessors registry throws error") {
       val loader = ConfigLoader {
-        withDefaultPreprocessors(null)
+        withDefaultPreprocessors(false)
         addMapSource(mapOf("custom_value" to "\${PATH}"))
       }
       val e = loader.loadConfig<Config>()

--- a/hoplite-core/src/test/kotlin/com/sksamuel/hoplite/WithoutDefaultsRegistryTest.kt
+++ b/hoplite-core/src/test/kotlin/com/sksamuel/hoplite/WithoutDefaultsRegistryTest.kt
@@ -19,7 +19,7 @@ class WithoutDefaultsRegistryTest : FunSpec() {
 
     test("empty sources registry throws error") {
       val loader = ConfigLoader {
-        withDefaultSources(false)
+        withDefaultSources(null)
         addMapSource(mapOf("custom_value" to "\${PATH}"))
       }
       val e = loader.loadConfig<Config>()
@@ -29,7 +29,7 @@ class WithoutDefaultsRegistryTest : FunSpec() {
 
     test("empty param mappers registry throws error") {
       val loader = ConfigLoader {
-        withDefaultParamMappers(false)
+        withDefaultParamMappers(null)
         addMapSource(mapOf("custom_value" to "\${PATH}"))
       }
 
@@ -40,7 +40,7 @@ class WithoutDefaultsRegistryTest : FunSpec() {
 
     test("empty preprocessors registry throws error") {
       val loader = ConfigLoader {
-        withDefaultPreprocessors(false)
+        withDefaultPreprocessors(null)
         addMapSource(mapOf("custom_value" to "\${PATH}"))
       }
       val e = loader.loadConfig<Config>()

--- a/hoplite-core/src/test/kotlin/com/sksamuel/hoplite/preprocessor/PropsPreprocessorTest.kt
+++ b/hoplite-core/src/test/kotlin/com/sksamuel/hoplite/preprocessor/PropsPreprocessorTest.kt
@@ -2,6 +2,7 @@ package com.sksamuel.hoplite.preprocessor
 
 import com.sksamuel.hoplite.ConfigLoader
 import io.kotest.core.spec.style.StringSpec
+import io.kotest.extensions.system.withEnvironment
 import io.kotest.matchers.shouldBe
 
 class PropsPreprocessorTest : StringSpec() {
@@ -12,11 +13,46 @@ class PropsPreprocessorTest : StringSpec() {
 
       val preprocessor = PropsPreprocessor("/sample.properties")
 
-      val config = ConfigLoader()
-        .withPreprocessor(preprocessor)
+      val config = ConfigLoader.Builder()
+        .addPreprocessor(preprocessor)
+        .build()
         .loadConfigOrThrow<Config>("/processme.props")
 
       config shouldBe Config(a = "I'm on branch master", b = "this replacement doesn't exist \${foo}")
+    }
+
+    "should replace props from file, by defaults before specified" {
+      data class Config(val a: String, val b: String)
+
+      withEnvironment(mapOf("git.branch" to "main")) {
+
+        val preprocessor = PropsPreprocessor("/sample.properties")
+
+        val config = ConfigLoader.Builder()
+          .addDefaultPreprocessors()
+          .addPreprocessor(preprocessor)
+          .build()
+          .loadConfigOrThrow<Config>("/processme.props")
+
+        config shouldBe Config(a = "I'm on branch main", b = "this replacement doesn't exist \${foo}")
+      }
+    }
+
+    "should replace props from file, by specified before defaults" {
+      data class Config(val a: String, val b: String)
+
+      withEnvironment(mapOf("git.branch" to "main", "foo" to "nevermind, it does!")) {
+        val preprocessor = PropsPreprocessor("/sample.properties")
+
+        val config = ConfigLoader.Builder()
+          .addPreprocessor(preprocessor)
+          .addDefaultPreprocessors()
+          .build()
+          .loadConfigOrThrow<Config>("/processme.props")
+
+        config shouldBe Config(a = "I'm on branch master",
+          b = "this replacement doesn't exist nevermind, it does!")
+      }
     }
   }
 }


### PR DESCRIPTION
The current implementation allows specifying, for instance, any kind of sources, while still adding the default ones.
However, it is always being added _before_ the specified ones.

I had to add it manually in my personal project, like this:
```kt
val configLoaderBuilder = ConfigLoader.Builder()
        .addMapSource(myConfigs)
        .addSources(defaultPropertySources())
        .withDefaultSources(false)
```
So I think it's best to have it specified.