### PR TITLE
Issue 230 data class with multiple constructors can select appropriate constructor to load

### DIFF
--- a/hoplite-core/src/test/kotlin/com/sksamuel/hoplite/WithoutDefaultsRegistryTest.kt
+++ b/hoplite-core/src/test/kotlin/com/sksamuel/hoplite/WithoutDefaultsRegistryTest.kt
@@ -13,8 +13,8 @@ class WithoutDefaultsRegistryTest : FunSpec() {
         addMapSource(mapOf("custom_value" to "\${PATH}"))
       }
       val e = loader.loadConfig<Config>()
-      e as Validated.Valid<Config>
-      e.value.customValue shouldNotBe "\${path}"
+      e as Validated.Invalid<ConfigFailure>
+      e.error shouldBe instanceOf(ConfigFailure.DataClassFieldErrors::class)
     }
 
     test("empty sources registry throws error") {
@@ -44,8 +44,8 @@ class WithoutDefaultsRegistryTest : FunSpec() {
         addMapSource(mapOf("custom_value" to "\${PATH}"))
       }
       val e = loader.loadConfig<Config>()
-      e as Validated.Valid<Config>
-      e.value.customValue shouldBe "\${PATH}"
+      e as Validated.Invalid<ConfigFailure>
+      e.error shouldBe instanceOf(ConfigFailure.DataClassFieldErrors::class)
     }
 
   }

--- a/hoplite-core/src/test/kotlin/com/sksamuel/hoplite/WithoutDefaultsRegistryTest.kt
+++ b/hoplite-core/src/test/kotlin/com/sksamuel/hoplite/WithoutDefaultsRegistryTest.kt
@@ -10,11 +10,11 @@ class WithoutDefaultsRegistryTest : FunSpec() {
   init {
     test("default registry throws no error") {
       val loader = ConfigLoader {
-        addMapSource(mapOf("custom_value" to "\${PATH}"))
+        addMapSource(mapOf("custom_value" to "\${PATH}", "PATH" to "\${PATH}"))
       }
       val e = loader.loadConfig<Config>()
-      e as Validated.Invalid<ConfigFailure>
-      e.error shouldBe instanceOf(ConfigFailure.DataClassFieldErrors::class)
+      e as Validated.Valid<Config>
+      e.value.customValue shouldNotBe "\${path}"
     }
 
     test("empty sources registry throws error") {
@@ -41,14 +41,14 @@ class WithoutDefaultsRegistryTest : FunSpec() {
     test("empty preprocessors registry throws error") {
       val loader = ConfigLoader {
         withDefaultPreprocessors(false)
-        addMapSource(mapOf("custom_value" to "\${PATH}"))
+        addMapSource(mapOf("custom_value" to "\${PATH}", "PATH" to "\${PATH}"))
       }
       val e = loader.loadConfig<Config>()
-      e as Validated.Invalid<ConfigFailure>
-      e.error shouldBe instanceOf(ConfigFailure.DataClassFieldErrors::class)
+      e as Validated.Valid<Config>
+      e.value.customValue shouldBe "\${PATH}"
     }
 
   }
-
+   // if your env vars is not "PATH" and is "Path" auto inject doesn't work
   data class Config(val PATH: String, val customValue: String)
 }


### PR DESCRIPTION
works when there is a single parameter "value" param constructor.  This fix changes DataClassDecoder to loop over all available constructors in an attempt to load class from a MapNode set of params.