### PR TITLE
Cleanup in hoplite-watch

### DIFF
--- a/hoplite-watch/build.gradle.kts
+++ b/hoplite-watch/build.gradle.kts
@@ -5,7 +5,6 @@ plugins {
 dependencies {
    api(project(":hoplite-core"))
    implementation(Libs.Kotlin.coroutines)
-   implementation(Libs.Snake.snakeyml)
 
    testImplementation(project(":hoplite-json"))
 }

--- a/hoplite-watch/src/main/resources/META-INF/services/com.sksamuel.hoplite.parsers.Parser
+++ b/hoplite-watch/src/main/resources/META-INF/services/com.sksamuel.hoplite.parsers.Parser
@@ -1,1 +1,0 @@
-com.sksamuel.hoplite.json.JsonParser


### PR DESCRIPTION
In my application I don't use JSON config files, but YAML one instead.
When I included `hoplite-watch` module in my application, it crashed with:
`Exception in thread "main" java.util.ServiceConfigurationError: com.sksamuel.hoplite.parsers.Parser: Provider com.sksamuel.hoplite.json.JsonParser not found`

I checked the source code and noticed that the JSON module is only used in tests, so I removed the file without any side effects. Tests passed and my application works correctly (tested with local Maven repo)