### PR TITLE
Call `.use` on the `InputStream`

### DIFF
--- a/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/ConfigFilePropertySource.kt
+++ b/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/ConfigFilePropertySource.kt
@@ -24,8 +24,7 @@ class ConfigFilePropertySource(
 
   override fun node(context: PropertySourceContext): ConfigResult<Node> {
     val parser = context.parsers.locate(config.ext())
-    val input = config.open()
-    return Validated.ap(parser, input) { a, b -> a.load(b, config.describe()) }
+    return Validated.ap(parser, config.open()) { a, b -> b.use { a.load(it, config.describe()) } }
       .mapInvalid { ConfigFailure.MultipleFailures(it) }
       .flatRecover { if (optional) Undefined.valid() else it.invalid() }
   }

--- a/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/ConfigSource.kt
+++ b/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/ConfigSource.kt
@@ -11,6 +11,10 @@ import java.nio.file.Path
 
 abstract class ConfigSource {
 
+  /**
+   * Opens a new [InputStream], the caller should call [AutoCloseable.close]
+   * when they no longer need the [InputStream].
+   */
   abstract fun open(): ConfigResult<InputStream>
   abstract fun describe(): String
   abstract fun ext(): String


### PR DESCRIPTION
`use` will close the stream after we use it.
Also, by inlining it, we prevent usage of the stream else where in the function.

Best I can tell, these inputstreams are currently never being closed.