### PR TITLE
Use JVM toolchains

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -47,6 +47,12 @@ allprojects {
       kotlinOptions.jvmTarget = "1.8"
    }
 
+   java {
+      toolchain {
+         languageVersion.set(JavaLanguageVersion.of(8))
+      }
+   }
+
    repositories {
       mavenLocal()
       mavenCentral()


### PR DESCRIPTION
This ensures that tasks that support JVM toolchains will run with JDK 8 even if Gradle is running with a different JDK version (e.g. 17)

https://docs.gradle.org/current/userguide/toolchains.html