### PR TITLE
Update to Kotlin 1.6.10

### DIFF
--- a/buildSrc/src/main/kotlin/Libs.kt
+++ b/buildSrc/src/main/kotlin/Libs.kt
@@ -7,7 +7,7 @@ object Libs {
     const val reflect = "org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion"
     const val stdlib = "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
     const val datetime = "org.jetbrains.kotlinx:kotlinx-datetime:0.2.0"
-    const val coroutines = "org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlinVersion"
+    const val coroutines = "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.5.0"
   }
 
   object Arrow {

--- a/buildSrc/src/main/kotlin/Libs.kt
+++ b/buildSrc/src/main/kotlin/Libs.kt
@@ -1,13 +1,13 @@
 object Libs {
 
-  const val kotlinVersion = "1.5.0"
+  const val kotlinVersion = "1.6.10"
   const val org = "com.sksamuel.hoplite"
 
   object Kotlin {
     const val reflect = "org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion"
     const val stdlib = "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
-    const val datetime = "org.jetbrains.kotlinx:kotlinx-datetime:0.2.0"
-    const val coroutines = "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.5.0"
+    const val datetime = "org.jetbrains.kotlinx:kotlinx-datetime:0.3.2"
+    const val coroutines = "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.0"
   }
 
   object Arrow {


### PR DESCRIPTION
Per https://github.com/sksamuel/hoplite/issues/226#issuecomment-1069678764

kotlin and kotlinx-coroutines-core happen to both offer version 1.5.0, but they won't always be the same version.

recent versions of kotlinx-coroutines-core:
1.5.0, 1.5.1, 1.5.2, 1.6.0 (latest)

recent versions of kotlin:
1.5.30, 1.5.31, 1.5.32, 1.6.0, 1.6.10 (latest)

kotlinx date-time 0.3.2 uses kotlin 1.6
https://github.com/Kotlin/kotlinx-datetime/releases/tag/v0.3.2