### PR TITLE
Pass in environmentVariableMap so that we can override it for tests.

### DIFF
--- a/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/EnvironmentVariablesPropertySource.kt
+++ b/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/EnvironmentVariablesPropertySource.kt
@@ -6,11 +6,12 @@ import java.util.Properties
 
 class EnvironmentVariablesPropertySource(
   private val useUnderscoresAsSeparator: Boolean,
-  private val allowUppercaseNames: Boolean
+  private val allowUppercaseNames: Boolean,
+  private val environmentVariableMap: () -> Map<String, String> = { System.getenv() },
 ) : PropertySource {
   override fun node(context: PropertySourceContext): ConfigResult<Node> {
     val props = Properties()
-    System.getenv().forEach {
+    environmentVariableMap().forEach {
       val key = it.key
         .let { key -> if (useUnderscoresAsSeparator) key.replace("__", ".") else key }
         .let { key ->

--- a/hoplite-json/src/test/kotlin/com/sksamuel/hoplite/json/EnvPropertySourceUppercaseTest.kt
+++ b/hoplite-json/src/test/kotlin/com/sksamuel/hoplite/json/EnvPropertySourceUppercaseTest.kt
@@ -3,7 +3,6 @@ package com.sksamuel.hoplite.json
 import com.sksamuel.hoplite.ConfigLoader
 import com.sksamuel.hoplite.EnvironmentVariablesPropertySource
 import io.kotest.core.spec.style.DescribeSpec
-import io.kotest.extensions.system.withEnvironment
 import io.kotest.matchers.shouldBe
 
 class EnvPropertySourceUppercaseTest : DescribeSpec({
@@ -13,34 +12,60 @@ class EnvPropertySourceUppercaseTest : DescribeSpec({
 
   describe("loading from envs") {
     it("with default options") {
-      withEnvironment(mapOf("CREDS.USERNAME" to "a", "CREDS.PASSWORD" to "c", "SOME_CAMEL_SETTING" to "c")) {
-        run {
-          ConfigLoader.Builder()
-            .addPropertySource(EnvironmentVariablesPropertySource(true, true))
-            .build()
-            .loadConfigOrThrow<Config>()
-        } shouldBe Config(Creds("a", "c"), "c")
-      }
+      run {
+        ConfigLoader {
+          addPropertySource(
+            EnvironmentVariablesPropertySource(
+              useUnderscoresAsSeparator = true,
+              allowUppercaseNames = true,
+              environmentVariableMap = {
+                mapOf(
+                  "CREDS.USERNAME" to "a",
+                  "CREDS.PASSWORD" to "c",
+                  "SOME_CAMEL_SETTING" to "c"
+                )
+              },
+            )
+          )
+        }.loadConfigOrThrow<Config>()
+      } shouldBe Config(Creds("a", "c"), "c")
     }
     it("with underscore separator") {
-      withEnvironment(mapOf("CREDS__USERNAME" to "a", "CREDS__PASSWORD" to "b", "SOME_CAMEL_SETTING" to "c")) {
-        run {
-          ConfigLoader.Builder()
-            .addPropertySource(EnvironmentVariablesPropertySource(true, true))
-            .build()
-            .loadConfigOrThrow<Config>()
-        } shouldBe Config(Creds("a", "b"), "c")
-      }
+      run {
+        ConfigLoader {
+          addPropertySource(
+            EnvironmentVariablesPropertySource(
+              useUnderscoresAsSeparator = true,
+              allowUppercaseNames = true,
+              environmentVariableMap = {
+                mapOf(
+                  "CREDS__USERNAME" to "a",
+                  "CREDS__PASSWORD" to "b",
+                  "SOME_CAMEL_SETTING" to "c"
+                )
+              },
+            )
+          )
+        }.loadConfigOrThrow<Config>()
+      } shouldBe Config(Creds("a", "b"), "c")
+
     }
     it("with lowercase names") {
-      withEnvironment(mapOf("creds__username" to "a", "creds__password" to "d", "someCamelSetting" to "e")) {
-        run {
-          ConfigLoader.Builder()
-            .addPropertySource(EnvironmentVariablesPropertySource(true, true))
-            .build()
-            .loadConfigOrThrow<Config>()
-        } shouldBe Config(Creds("a", "d"), "e")
-      }
+      run {
+        ConfigLoader {
+          addPropertySource(EnvironmentVariablesPropertySource(
+            useUnderscoresAsSeparator = true,
+            allowUppercaseNames = true,
+            environmentVariableMap = {
+              mapOf(
+                "creds__username" to "a",
+                "creds__password" to "d",
+                "someCamelSetting" to "e"
+              )
+            }
+          ))
+        }.loadConfigOrThrow<Config>()
+      } shouldBe Config(Creds("a", "d"), "e")
     }
   }
 })


### PR DESCRIPTION
This will make it easier for consumers of hoplite to test their `ConfigLoader` setup, as they can just pass in a map with the desired test values. 

Else you have to try and manipulate some global state, which is error prone and not thread safe. 

From the [kotest `withEnvironment` docs](https://github.com/kotest/kotest/blob/0ba14983d485b1b1caef0e5a2cd7402ba47e34d2/kotest-extensions/src/jvmMain/kotlin/io/kotest/extensions/system/SystemPropertiesExtensions.kt#L21-L22): 
> ATTENTION: This code is susceptible to race conditions. If you attempt to change the environment while it was already changed, the result is inconsistent, as the System Environment Map is a single map.

Also, this makes it easier for consumers of hoplite to use `EnvironmentVariablesPropertySource` in tests without kotest.


