### PR TITLE
Use kotlin-stdlib-jdk8

### DIFF
--- a/buildSrc/src/main/kotlin/Libs.kt
+++ b/buildSrc/src/main/kotlin/Libs.kt
@@ -5,7 +5,7 @@ object Libs {
 
   object Kotlin {
     const val reflect = "org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion"
-    const val stdlib = "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
+    const val stdlib = "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlinVersion"
     const val datetime = "org.jetbrains.kotlinx:kotlinx-datetime:0.3.2"
     const val coroutines = "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.0"
   }

--- a/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/UserSettingsPropertySource.kt
+++ b/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/UserSettingsPropertySource.kt
@@ -3,6 +3,8 @@ package com.sksamuel.hoplite
 import com.sksamuel.hoplite.fp.valid
 import java.nio.file.Path
 import java.nio.file.Paths
+import kotlin.io.path.exists
+import kotlin.io.path.inputStream
 
 /**
  * An implementation of [PropertySource] that provides config through a config file
@@ -20,11 +22,11 @@ object UserSettingsPropertySource : PropertySource {
 
   override fun node(context: PropertySourceContext): ConfigResult<Node> {
     val ext = context.parsers.registeredExtensions().firstOrNull {
-      path(it).toFile().exists()
+      path(it).exists()
     }
     return if (ext == null) Undefined.valid() else {
       val path = path(ext)
-      val input = path.toFile().inputStream()
+      val input = path.inputStream()
       context.parsers.locate(ext).map {
         it.load(input, path.toString())
       }


### PR DESCRIPTION
`kotlin-stdlib` restricts you to JDK 6 based APIs.
`kotlin-stdlib-jdk8` includes APIs that use JDK 8 APIs.

e.g. here are a few APIs that come with `kotlin-stdlib-jdk8`:
import kotlin.io.path.exists
import kotlin.io.path.inputStream