### PR TITLE
Make SystemPropertiesPropertySource easier to test

### DIFF
--- a/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/SystemPropertiesPropertySource.kt
+++ b/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/SystemPropertiesPropertySource.kt
@@ -10,14 +10,31 @@ import java.util.Properties
  * In other words, if a System property is defined 'config.override.user.name=sam' then
  * the property 'user.name=sam' is made available.
  */
-object SystemPropertiesPropertySource : PropertySource {
-  private const val prefix = "config.override."
+open class SystemPropertiesPropertySource(
+  private val systemPropertiesMap: () -> Map<String, String> = { System.getProperties().toStringMap() }
+) : PropertySource {
   override fun node(context: PropertySourceContext): ConfigResult<Node> {
     val props = Properties()
-    System.getProperties()
-      .stringPropertyNames()
-      .filter { it.startsWith(prefix) }
-      .forEach { props[it.removePrefix(prefix)] = System.getProperty(it) }
+    systemPropertiesMap().let { systemPropertiesMap ->
+      systemPropertiesMap.keys
+        .filter { it.startsWith(prefix) }
+        .forEach { props[it.removePrefix(prefix)] = systemPropertiesMap[it] }
+    }
     return if (props.isEmpty) Undefined.valid() else props.toNode("sysprops").valid()
+  }
+
+  companion object : SystemPropertiesPropertySource() {
+    private const val prefix = "config.override."
+
+    // for backwards compatibility with Java from when SystemPropertiesPropertySource was an `object`
+    @Suppress("unused")
+    @JvmField
+    val INSTANCE: SystemPropertiesPropertySource = this
+  }
+}
+
+internal fun Properties.toStringMap(): Map<String, String> = this.let { systemProperties ->
+  systemProperties.stringPropertyNames().associateWith { propertyName ->
+    systemProperties.getProperty(propertyName)
   }
 }

--- a/hoplite-core/src/test/kotlin/com/sksamuel/hoplite/SystemPropertiesPropertySourceTest.kt
+++ b/hoplite-core/src/test/kotlin/com/sksamuel/hoplite/SystemPropertiesPropertySourceTest.kt
@@ -1,0 +1,59 @@
+package com.sksamuel.hoplite
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.maps.shouldContainExactly
+import io.kotest.matchers.shouldBe
+import java.util.Properties
+class SystemPropertiesPropertySourceTest : FunSpec() {
+  init {
+    test("reads config from string") {
+      data class TestConfig(val a: String, val b: Int)
+
+      val config = ConfigLoader {
+        withDefaultSources(false)
+        addPropertySource(
+          SystemPropertiesPropertySource(
+            systemPropertiesMap = {
+              mapOf("config.override.a" to "Overridden by system prop")
+            },
+          )
+        )
+        addPropertySource(
+          PropertySource.string(
+            """
+          a = A value
+          b = 42
+          """.trimIndent(), "props"
+          )
+        )
+      }.loadConfigOrThrow<TestConfig>()
+
+      config shouldBe TestConfig("Overridden by system prop", 42)
+    }
+
+    test("reads from real system props") {
+      data class TestConfig(val a: String, val b: Int)
+
+      try {
+        // this is an error prone test because we have to remember to clear these properties after the test
+        System.setProperty("config.override.a", "Overridden by system prop")
+        System.setProperty("config.override.b", "42")
+
+        // use default property sources to load system properties
+        ConfigLoader().loadConfigOrThrow<TestConfig>() shouldBe TestConfig("Overridden by system prop", 42)
+      } finally {
+        System.clearProperty("config.override.a")
+        System.clearProperty("config.override.b")
+      }
+    }
+
+    test("properties toStringMap extension function ignores non-string types") {
+      Properties().apply {
+        setProperty("foo", "bar")
+        put("name", "value") // same as setProperty when you use String args
+        put(42, "int") // should be ignored because key is not a string
+        put("int", listOf(42)) // should be ignored because value is not a string
+      }.toStringMap() shouldContainExactly mapOf("foo" to "bar", "name" to "value")
+    }
+  }
+}


### PR DESCRIPTION
Calling System.getProperties() directly makes this hard to test
because it involved global mutable state and you have to
remember to `clearProperty` whenever you set the property.

This allows you to just pass a map directly for system properties, and override it in tests.