### PR TITLE
Update RegionDecoder.kt

### DIFF
--- a/hoplite-aws2/src/main/kotlin/com/sksamuel/hoplite/aws2/RegionDecoder.kt
+++ b/hoplite-aws2/src/main/kotlin/com/sksamuel/hoplite/aws2/RegionDecoder.kt
@@ -12,7 +12,7 @@ import software.amazon.awssdk.regions.Region
 import java.util.Locale
 import kotlin.reflect.KType
 
-object RegionDecoder : NullHandlingDecoder<Region> {
+class RegionDecoder : NullHandlingDecoder<Region> {
 
   override fun supports(type: KType): Boolean = type.classifier == Region::class
 


### PR DESCRIPTION
Seems it needs to be instantiated for the service discovery mechanism to work..

Since it is an object, is has no public no-arg constructor, and using it fails with:

```
  java.util.ServiceConfigurationError: com.sksamuel.hoplite.decoder.Decoder: com.sksamuel.hoplite.aws2.RegionDecoder Unable to get public no-arg constructor

  Caused by: java.util.ServiceConfigurationError: com.sksamuel.hoplite.decoder.Decoder: com.sksamuel.hoplite.aws2.RegionDecoder Unable to get public no-arg constructor

  Caused by: java.lang.NoSuchMethodException: com.sksamuel.hoplite.aws2.RegionDecoder.<init>()
```