### PR TITLE
Mark map value nodes as used (fixes #320)

### DIFF
--- a/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/decoder/MapDecoder.kt
+++ b/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/decoder/MapDecoder.kt
@@ -37,6 +37,7 @@ class MapDecoder : NullHandlingDecoder<Map<*, *>> {
       return node.map.entries.map { (k, v) ->
         kdecoder.decode(StringNode(k, node.pos, node.path), kType, context).flatMap { kk ->
           vdecoder.decode(v, vType, context).map { vv ->
+            context.usedPaths.add(v.path)
             kk to vv
           }
         }

--- a/hoplite-yaml/src/test/kotlin/com/sksamuel/hoplite/yaml/StrictModeTest.kt
+++ b/hoplite-yaml/src/test/kotlin/com/sksamuel/hoplite/yaml/StrictModeTest.kt
@@ -80,5 +80,20 @@ class StrictModeTest : FunSpec() {
         .loadConfigOrThrow<Foo>()
         .bubbleBobble shouldBe "xyz"
     }
+
+    test("strict mode should not error when using maps") {
+      data class NumberDescription(
+        val number: Int
+      )
+      data class NumberMapContainer(
+        val counting: Map<String, NumberDescription>
+      )
+
+      ConfigLoaderBuilder
+        .default()
+        .strict()
+        .build()
+        .loadConfigOrThrow<NumberMapContainer>("/numbers_map.yml")
+    }
   }
 }

--- a/hoplite-yaml/src/test/resources/numbers_map.yml
+++ b/hoplite-yaml/src/test/resources/numbers_map.yml
@@ -1,0 +1,7 @@
+counting:
+  one:
+    number: 1
+  two:
+    number: 2
+  three:
+    number: 3


### PR DESCRIPTION
This should fix #320 

I'm not sure if this is the best approach for this though, feel free to tell me if there's a better solution for this. I have added a test case for this. Said test failed before the modification to the map decoder, and now passes.