### PR TITLE
Do not treat quoted keys with dots as paths in TomlParser

### DIFF
--- a/hoplite-toml/src/test/kotlin/com/sksamuel/hoplite/toml/MapTest.kt
+++ b/hoplite-toml/src/test/kotlin/com/sksamuel/hoplite/toml/MapTest.kt
@@ -1,0 +1,25 @@
+package com.sksamuel.hoplite.toml
+
+import com.sksamuel.hoplite.ConfigLoader
+import io.kotest.assertions.throwables.shouldNotThrowAny
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+
+class MapTest : StringSpec({
+  "Map key contains dots" {
+    data class CountEntry(val number: Int)
+    data class Config(val count: Map<String, CountEntry>)
+
+    val config = shouldNotThrowAny {
+      ConfigLoader().loadConfigOrThrow<Config>("/key_with_dots_in_map.toml")
+    }
+    config shouldBe Config(
+      count = mapOf(
+        "one" to CountEntry(1),
+        "twenty.two" to CountEntry(22),
+        "nine.one.one" to CountEntry(911),
+        "one.hundred.and.ten" to CountEntry(110)
+      )
+    )
+  }
+})

--- a/hoplite-toml/src/test/resources/key_with_dots_in_map.toml
+++ b/hoplite-toml/src/test/resources/key_with_dots_in_map.toml
@@ -1,0 +1,11 @@
+[count.one]
+number = 1
+
+[count."twenty.two"]
+number = 22
+
+[count."nine.one.one"]
+number = 911
+
+[count."one.hundred.and.ten"]
+number = 110


### PR DESCRIPTION
Fixes #322 

- [x] Add failing test case
- [x] Investigate why it's not working
- [x] Provide fix