### PR TITLE
Fix sealed subclass picking

### DIFF
--- a/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/decoder/SealedClassDecoder.kt
+++ b/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/decoder/SealedClassDecoder.kt
@@ -65,7 +65,13 @@ class SealedClassDecoder : NullHandlingDecoder<Any> {
           .filter { subclass ->
             subclass hasConstructorsWithArgumentsNumberLessOrEqualTo node.expectedNumberOfConstructorArguments
           }
-          .sortedByDescending { subclass -> subclass.constructors.maxOfOrNull { it.numberOfMandatoryArguments } ?: 0 }
+          .sortedWith { subclass1, subclass2 ->
+            (
+              subclass1.numberOfMandatoryConstructorArguments.compareTo(subclass2.numberOfMandatoryConstructorArguments)
+                .takeUnless { it == 0 }
+                ?: subclass1.numberOfTotalConstructorArguments.compareTo(subclass2.numberOfTotalConstructorArguments)
+              ) * -1
+          }
           .map { DataClassDecoder().decode(node, it.createType(), context) }
 
         val success = results.firstOrNull { it.isValid() }
@@ -77,10 +83,17 @@ class SealedClassDecoder : NullHandlingDecoder<Any> {
     }
   }
 
+  private val KClass<*>.numberOfTotalConstructorArguments
+    get() = constructors.maxOfOrNull { it.numberOfTotalArguments } ?: 0
+
+  private val KClass<*>.numberOfMandatoryConstructorArguments
+    get() = constructors.maxOfOrNull { it.numberOfMandatoryArguments } ?: 0
+
   private infix fun KClass<*>.hasConstructorsWithArgumentsNumberLessOrEqualTo(number: Int) =
     constructors.map { it.numberOfMandatoryArguments }.any { it <= number }
 
   private val KFunction<*>.numberOfMandatoryArguments get() = parameters.filterNot { it.isOptional }.size
+  private val KFunction<*>.numberOfTotalArguments get() = parameters.size
 
   private val Node.expectedNumberOfConstructorArguments get() = size.takeIf { it > 0 } ?: 1
 }

--- a/hoplite-hocon/src/test/kotlin/com/sksamuel/hoplite/hocon/SealedClassTest.kt
+++ b/hoplite-hocon/src/test/kotlin/com/sksamuel/hoplite/hocon/SealedClassTest.kt
@@ -8,15 +8,15 @@ import io.kotest.matchers.shouldBe
 sealed class ClientAuthConfig {
   data class UrlUserPass(val url: String, val user: String, val password: Masked) : ClientAuthConfig()
 
-  data class UrlWithWithDefaultValue(val otherStuff: String = "", val anotherStuff: String = "") : ClientAuthConfig()
+  data class ConfigWithDefaultValues(val otherStuff: String = "", val anotherStuff: String = "") : ClientAuthConfig()
   data class Url(val url: String) : ClientAuthConfig()
 }
 
 data class DbConfig(
   val clientAuth: ClientAuthConfig,
-  val clientNoAuth: ClientAuthConfig = ClientAuthConfig.UrlWithWithDefaultValue(),
+  val clientNoAuth: ClientAuthConfig = ClientAuthConfig.ConfigWithDefaultValues(),
   val clientWithSpecifiedValues: ClientAuthConfig,
-  val clientWithDefaultValues: ClientAuthConfig = ClientAuthConfig.UrlWithWithDefaultValue(),
+  val clientWithDefaultValues: ClientAuthConfig = ClientAuthConfig.ConfigWithDefaultValues(),
 )
 
 class SealedClassTest : FunSpec() {
@@ -29,11 +29,11 @@ class SealedClassTest : FunSpec() {
         password = Masked("3pass"),
       )
       config.clientNoAuth shouldBe ClientAuthConfig.Url(url = "1url")
-      config.clientWithSpecifiedValues shouldBe ClientAuthConfig.UrlWithWithDefaultValue(
+      config.clientWithSpecifiedValues shouldBe ClientAuthConfig.ConfigWithDefaultValues(
         otherStuff = "1url",
         anotherStuff = "test"
       )
-      config.clientWithDefaultValues shouldBe ClientAuthConfig.UrlWithWithDefaultValue()
+      config.clientWithDefaultValues shouldBe ClientAuthConfig.ConfigWithDefaultValues()
     }
   }
 }

--- a/hoplite-hocon/src/test/kotlin/com/sksamuel/hoplite/hocon/SealedClassTest.kt
+++ b/hoplite-hocon/src/test/kotlin/com/sksamuel/hoplite/hocon/SealedClassTest.kt
@@ -2,20 +2,21 @@ package com.sksamuel.hoplite.hocon
 
 import com.sksamuel.hoplite.ConfigLoader
 import com.sksamuel.hoplite.Masked
-import com.sksamuel.hoplite.hocon.ClientAuthConfig.UrlWithWithDefaultValue
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 
 sealed class ClientAuthConfig {
   data class UrlUserPass(val url: String, val user: String, val password: Masked) : ClientAuthConfig()
 
-  data class UrlWithWithDefaultValue(val url: String = "", val otherStuff: String = "") : ClientAuthConfig()
+  data class UrlWithWithDefaultValue(val otherStuff: String = "", val anotherStuff: String = "") : ClientAuthConfig()
   data class Url(val url: String) : ClientAuthConfig()
 }
 
 data class DbConfig(
   val clientAuth: ClientAuthConfig,
-  val clientNoAuth: ClientAuthConfig = UrlWithWithDefaultValue(),
+  val clientNoAuth: ClientAuthConfig = ClientAuthConfig.UrlWithWithDefaultValue(),
+  val clientWithSpecifiedValues: ClientAuthConfig,
+  val clientWithDefaultValues: ClientAuthConfig = ClientAuthConfig.UrlWithWithDefaultValue(),
 )
 
 class SealedClassTest : FunSpec() {
@@ -28,6 +29,11 @@ class SealedClassTest : FunSpec() {
         password = Masked("3pass"),
       )
       config.clientNoAuth shouldBe ClientAuthConfig.Url(url = "1url")
+      config.clientWithSpecifiedValues shouldBe ClientAuthConfig.UrlWithWithDefaultValue(
+        otherStuff = "1url",
+        anotherStuff = "test"
+      )
+      config.clientWithDefaultValues shouldBe ClientAuthConfig.UrlWithWithDefaultValue()
     }
   }
 }

--- a/hoplite-hocon/src/test/kotlin/com/sksamuel/hoplite/hocon/SealedClassTest.kt
+++ b/hoplite-hocon/src/test/kotlin/com/sksamuel/hoplite/hocon/SealedClassTest.kt
@@ -2,15 +2,21 @@ package com.sksamuel.hoplite.hocon
 
 import com.sksamuel.hoplite.ConfigLoader
 import com.sksamuel.hoplite.Masked
+import com.sksamuel.hoplite.hocon.ClientAuthConfig.UrlWithWithDefaultValue
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 
 sealed class ClientAuthConfig {
   data class UrlUserPass(val url: String, val user: String, val password: Masked) : ClientAuthConfig()
+
+  data class UrlWithWithDefaultValue(val url: String = "", val otherStuff: String = "") : ClientAuthConfig()
   data class Url(val url: String) : ClientAuthConfig()
 }
 
-data class DbConfig(val clientAuth: ClientAuthConfig, val clientNoAuth: ClientAuthConfig)
+data class DbConfig(
+  val clientAuth: ClientAuthConfig,
+  val clientNoAuth: ClientAuthConfig = UrlWithWithDefaultValue(),
+)
 
 class SealedClassTest : FunSpec() {
   init {

--- a/hoplite-hocon/src/test/kotlin/com/sksamuel/hoplite/hocon/SealedClassTest.kt
+++ b/hoplite-hocon/src/test/kotlin/com/sksamuel/hoplite/hocon/SealedClassTest.kt
@@ -8,15 +8,18 @@ import io.kotest.matchers.shouldBe
 sealed class ClientAuthConfig {
   data class UrlUserPass(val url: String, val user: String, val password: Masked) : ClientAuthConfig()
 
-  data class ConfigWithDefaultValues(val otherStuff: String = "", val anotherStuff: String = "") : ClientAuthConfig()
+  data class ConfigWithOneDefaultValue(val otherStuff: String = "") : ClientAuthConfig()
+
+  data class ConfigWithTwoDefaultValues(val otherStuff: String = "", val anotherStuff: String = "") : ClientAuthConfig()
   data class Url(val url: String) : ClientAuthConfig()
 }
 
 data class DbConfig(
   val clientAuth: ClientAuthConfig,
-  val clientNoAuth: ClientAuthConfig = ClientAuthConfig.ConfigWithDefaultValues(),
-  val clientWithSpecifiedValues: ClientAuthConfig,
-  val clientWithDefaultValues: ClientAuthConfig = ClientAuthConfig.ConfigWithDefaultValues(),
+  val clientNoAuth: ClientAuthConfig = ClientAuthConfig.ConfigWithOneDefaultValue(),
+  val clientWithOneSpecifiedValue: ClientAuthConfig,
+  val clientWithTwoSpecifiedValue: ClientAuthConfig,
+  val clientWithDefaultValues: ClientAuthConfig = ClientAuthConfig.ConfigWithOneDefaultValue(),
 )
 
 class SealedClassTest : FunSpec() {
@@ -29,11 +32,14 @@ class SealedClassTest : FunSpec() {
         password = Masked("3pass"),
       )
       config.clientNoAuth shouldBe ClientAuthConfig.Url(url = "1url")
-      config.clientWithSpecifiedValues shouldBe ClientAuthConfig.ConfigWithDefaultValues(
+      config.clientWithOneSpecifiedValue shouldBe ClientAuthConfig.ConfigWithTwoDefaultValues(
+        otherStuff = "1url",
+      )
+      config.clientWithTwoSpecifiedValue shouldBe ClientAuthConfig.ConfigWithTwoDefaultValues(
         otherStuff = "1url",
         anotherStuff = "test"
       )
-      config.clientWithDefaultValues shouldBe ClientAuthConfig.ConfigWithDefaultValues()
+      config.clientWithDefaultValues shouldBe ClientAuthConfig.ConfigWithOneDefaultValue()
     }
   }
 }

--- a/hoplite-hocon/src/test/resources/sealed.conf
+++ b/hoplite-hocon/src/test/resources/sealed.conf
@@ -8,7 +8,11 @@ clientNoAuth {
     url = "1url"
 }
 
-clientWithSpecifiedValues {
+clientWithOneSpecifiedValue {
+    otherStuff = "1url"
+}
+
+clientWithTwoSpecifiedValue {
     otherStuff = "1url"
     anotherStuff = "test"
 }

--- a/hoplite-hocon/src/test/resources/sealed.conf
+++ b/hoplite-hocon/src/test/resources/sealed.conf
@@ -7,3 +7,8 @@ clientAuth {
 clientNoAuth {
     url = "1url"
 }
+
+clientWithSpecifiedValues {
+    otherStuff = "1url"
+    anotherStuff = "test"
+}


### PR DESCRIPTION
As a follow-up to #331 fix, this changes the sealed subclass picking logic,

If there are subclasses having more mandatory constructor arguments than the number of configuration properties provided, then such subclasses will be ignored at all.

If there are 2 classes having the same number of arguments in constructor: one with optional and one with mandatory, the one with mandatory will be preferred.

If there are 2 classes having the same number of mandatory arguments in the constructor, the one having higher total number of arguments will be preferred.