### PR TITLE
WIP handling empty resources - having trouble with generics

### DIFF
--- a/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/ConfigFailure.kt
+++ b/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/ConfigFailure.kt
@@ -96,6 +96,10 @@ sealed interface ConfigFailure {
     override fun description(): String = "Could not find config file $source"
   }
 
+  data class EmptySource(val source: String) : ConfigFailure {
+    override fun description(): String = "Source $source is empty"
+  }
+
   data class MultipleFailures(val failures: NonEmptyList<ConfigFailure>) : ConfigFailure {
     override fun description(): String = failures.map { it.description() }.list.joinToString("\n\n")
   }

--- a/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/sources/ConfigFilePropertySource.kt
+++ b/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/sources/ConfigFilePropertySource.kt
@@ -36,7 +36,7 @@ class ConfigFilePropertySource(
 
   override fun node(context: PropertySourceContext): ConfigResult<Node> {
     val parser = context.parsers.locate(config.ext())
-    return Validated.ap(parser, config.open()) { a, b -> b.use { a.load(it, config.describe()) } }
+    return Validated.ap(parser, config.open()) { a, b -> if (b.available() > 0) b.use { a.load(it, config.describe()) } else ConfigFailure.EmptySource(config.describe()).invalid() }
       .mapInvalid { ConfigFailure.MultipleFailures(it) }
       .flatRecover { if (optional) Undefined.valid() else it.invalid() }
   }


### PR DESCRIPTION
See issue: https://github.com/sksamuel/hoplite/issues/340
The objective is to allow handling empty resource files without throwing an error, e.g.:

```
Caused by: java.lang.IllegalArgumentException: Expected document start at  in 'reader', line 1, column 1:
    
    ^
	at com.sksamuel.hoplite.yaml.YamlParser.load(YamlParser.kt:38)
	at com.sksamuel.hoplite.sources.ConfigFilePropertySource$node$1.invoke(ConfigFilePropertySource.kt:36)
	at com.sksamuel.hoplite.sources.ConfigFilePropertySource$node$1.invoke(ConfigFilePropertySource.kt:36)
	at com.sksamuel.hoplite.fp.Validated$Companion.ap(Validated.kt:70)
	at com.sksamuel.hoplite.sources.ConfigFilePropertySource.node(ConfigFilePropertySource.kt:36)
	at com.sksamuel.hoplite.NodeParser.parseNode(NodeParser.kt:29)
	at com.sksamuel.hoplite.ConfigLoader.loadConfig(ConfigLoader.kt:136)
	at com.smartnews.cg.configuration.BuildConfigKt.<clinit>(BuildConfig.kt:169)
	... 3 more
```

Unfortunately, I can't quite figure out how to get the generics to compile.
The error my change is giving me is:

```
Type mismatch.
Required:
ConfigResult<Node> /* = Validated<ConfigFailure, Node> */
Found:
Validated<ConfigFailure.MultipleFailures, Any>
```

My change is returning `Validated<ConfigFailure.MultipleFailures, Any>` vs. the expected `Validated<ConfigFailure, Node>`.