### PR TITLE
feat: EnumDecoder: support case-insensitive decoding

### DIFF
--- a/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/ConfigLoader.kt
+++ b/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/ConfigLoader.kt
@@ -12,8 +12,8 @@ import com.sksamuel.hoplite.internal.DecodeMode
 import com.sksamuel.hoplite.parsers.ParserRegistry
 import com.sksamuel.hoplite.preprocessor.Preprocessor
 import com.sksamuel.hoplite.report.Print
-import com.sksamuel.hoplite.resolver.context.ContextResolverMode
 import com.sksamuel.hoplite.resolver.Resolver
+import com.sksamuel.hoplite.resolver.context.ContextResolverMode
 import com.sksamuel.hoplite.secrets.Obfuscator
 import com.sksamuel.hoplite.secrets.PrefixObfuscator
 import com.sksamuel.hoplite.secrets.SecretsPolicy
@@ -44,6 +44,7 @@ class ConfigLoader(
   val resolvers: List<Resolver> = emptyList(),
   val sealedTypeDiscriminatorField: String? = null,
   val allowNullOverride: Boolean = false,
+  val resolveTypesCaseInsensitive: Boolean = false,
   val contextResolverMode: ContextResolverMode = ContextResolverMode.ErrorOnUnresolved,
 ) {
 
@@ -164,6 +165,7 @@ class ConfigLoader(
       parserRegistry = parserRegistry,
       allowEmptyTree = allowEmptyTree,
       allowNullOverride = allowNullOverride,
+      resolveTypesCaseInsensitive = resolveTypesCaseInsensitive,
       cascadeMode = cascadeMode,
       preprocessors = preprocessors,
       preprocessingIterations = preprocessingIterations,
@@ -218,6 +220,7 @@ class ConfigLoader(
       parserRegistry = parserRegistry,
       allowEmptyTree = allowEmptyTree,
       allowNullOverride = allowNullOverride,
+      resolveTypesCaseInsensitive = resolveTypesCaseInsensitive,
       cascadeMode = cascadeMode,
       preprocessors = preprocessors,
       preprocessingIterations = preprocessingIterations,

--- a/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/ConfigLoaderBuilder.kt
+++ b/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/ConfigLoaderBuilder.kt
@@ -13,13 +13,13 @@ import com.sksamuel.hoplite.preprocessor.Preprocessor
 import com.sksamuel.hoplite.preprocessor.RandomPreprocessor
 import com.sksamuel.hoplite.report.Print
 import com.sksamuel.hoplite.report.Reporter
+import com.sksamuel.hoplite.resolver.Resolver
 import com.sksamuel.hoplite.resolver.context.ContextResolverMode
 import com.sksamuel.hoplite.resolver.context.EnvVarContextResolver
 import com.sksamuel.hoplite.resolver.context.HopliteContextResolver
 import com.sksamuel.hoplite.resolver.context.ManifestContextResolver
-import com.sksamuel.hoplite.resolver.context.ReferenceContextResolver
-import com.sksamuel.hoplite.resolver.Resolver
 import com.sksamuel.hoplite.resolver.context.RandomContextResolver
+import com.sksamuel.hoplite.resolver.context.ReferenceContextResolver
 import com.sksamuel.hoplite.resolver.context.SystemContextResolver
 import com.sksamuel.hoplite.resolver.context.SystemPropertyContextResolver
 import com.sksamuel.hoplite.secrets.AllStringNodesSecretsPolicy
@@ -45,6 +45,7 @@ class ConfigLoaderBuilder private constructor() {
   private var allowEmptyConfigFiles = false
   private var allowNullOverride = false
   private var allowUnresolvedSubstitutions = false
+  private var resolveTypesCaseInsensitive = false
   private var sealedTypeDiscriminatorField: String? = null
   private var contextResolverMode = ContextResolverMode.ErrorOnUnresolved
 
@@ -298,6 +299,13 @@ class ConfigLoaderBuilder private constructor() {
     allowUnresolvedSubstitutions = true
   }
 
+  /**
+   * When enabled, makes type/enum name resolution case-insensitive
+   */
+  fun withResolveTypesCaseInsensitive(): ConfigLoaderBuilder = apply {
+    resolveTypesCaseInsensitive = true
+  }
+
   fun withContextResolverMode(mode: ContextResolverMode) = apply {
     contextResolverMode = mode
   }
@@ -371,6 +379,7 @@ class ConfigLoaderBuilder private constructor() {
       useReport = useReport,
       allowEmptyTree = allowEmptyConfigFiles,
       allowNullOverride = allowNullOverride,
+      resolveTypesCaseInsensitive = resolveTypesCaseInsensitive,
       allowUnresolvedSubstitutions = allowUnresolvedSubstitutions,
       preprocessingIterations = preprocessingIterations,
       cascadeMode = cascadeMode,

--- a/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/DecoderContext.kt
+++ b/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/DecoderContext.kt
@@ -5,8 +5,8 @@ import com.sksamuel.hoplite.decoder.DecoderRegistry
 import com.sksamuel.hoplite.decoder.DotPath
 import com.sksamuel.hoplite.env.Environment
 import com.sksamuel.hoplite.fp.Validated
-import com.sksamuel.hoplite.resolver.context.ContextResolverMode
 import com.sksamuel.hoplite.resolver.Resolving
+import com.sksamuel.hoplite.resolver.context.ContextResolverMode
 import kotlin.reflect.KParameter
 import kotlin.reflect.KType
 
@@ -27,7 +27,7 @@ data class DecoderContext(
   // this tracks the types that a node was marshalled into
   val used: MutableMap<DotPath, NodeState> = mutableMapOf(),
   val metadata: MutableMap<String, Any?> = mutableMapOf(),
-  val config: DecoderConfig = DecoderConfig(false),
+  val config: DecoderConfig = DecoderConfig(flattenArraysToString = false, resolveTypesCaseInsensitive = false),
   val environment: Environment? = null,
   val resolvers: Resolving = Resolving.empty,
   // determines if we should error when a context resolver cannot find a substitution
@@ -72,5 +72,6 @@ data class NodeState(
 )
 
 data class DecoderConfig(
-  val flattenArraysToString: Boolean
+  val flattenArraysToString: Boolean,
+  val resolveTypesCaseInsensitive: Boolean,
 )

--- a/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/decoder/enum.kt
+++ b/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/decoder/enum.kt
@@ -16,8 +16,6 @@ import kotlin.reflect.KType
 @Suppress("UNCHECKED_CAST")
 class EnumDecoder<T : Any>(private val ignoreCase: Boolean = false) : NullHandlingDecoder<T> {
 
-  override fun priority(): Int = super.priority().takeUnless { ignoreCase } ?: 0
-
   override fun supports(type: KType): Boolean = type.classifier is KClass<*> && (type.classifier as KClass<*>).java.isEnum
 
   override fun safeDecode(node: Node,

--- a/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/decoder/enum.kt
+++ b/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/decoder/enum.kt
@@ -1,20 +1,20 @@
 package com.sksamuel.hoplite.decoder
 
-import com.sksamuel.hoplite.fp.invalid
-import com.sksamuel.hoplite.fp.valid
 import com.sksamuel.hoplite.BooleanNode
 import com.sksamuel.hoplite.ConfigFailure
 import com.sksamuel.hoplite.ConfigResult
 import com.sksamuel.hoplite.DecoderContext
 import com.sksamuel.hoplite.DoubleNode
 import com.sksamuel.hoplite.LongNode
-import com.sksamuel.hoplite.StringNode
 import com.sksamuel.hoplite.Node
+import com.sksamuel.hoplite.StringNode
+import com.sksamuel.hoplite.fp.invalid
+import com.sksamuel.hoplite.fp.valid
 import kotlin.reflect.KClass
 import kotlin.reflect.KType
 
 @Suppress("UNCHECKED_CAST")
-class EnumDecoder<T : Any> : NullHandlingDecoder<T> {
+class EnumDecoder<T : Any>(private val ignoreCase: Boolean = false) : NullHandlingDecoder<T> {
 
   override fun supports(type: KType): Boolean = type.classifier is KClass<*> && (type.classifier as KClass<*>).java.isEnum
 
@@ -26,7 +26,7 @@ class EnumDecoder<T : Any> : NullHandlingDecoder<T> {
     val klass = type.classifier as KClass<*>
 
     fun decode(value: String): ConfigResult<T> {
-      val t = klass.java.enumConstants.find { it.toString() == value }
+      val t = klass.java.enumConstants.find { it.toString().contentEquals(value, ignoreCase) }
       return if (t == null)
         ConfigFailure.InvalidEnumConstant(node, type, value).invalid()
       else

--- a/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/decoder/enum.kt
+++ b/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/decoder/enum.kt
@@ -16,6 +16,8 @@ import kotlin.reflect.KType
 @Suppress("UNCHECKED_CAST")
 class EnumDecoder<T : Any>(private val ignoreCase: Boolean = false) : NullHandlingDecoder<T> {
 
+  override fun priority(): Int = super.priority().takeUnless { ignoreCase } ?: 0
+
   override fun supports(type: KType): Boolean = type.classifier is KClass<*> && (type.classifier as KClass<*>).java.isEnum
 
   override fun safeDecode(node: Node,

--- a/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/decoder/enum.kt
+++ b/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/decoder/enum.kt
@@ -14,7 +14,7 @@ import kotlin.reflect.KClass
 import kotlin.reflect.KType
 
 @Suppress("UNCHECKED_CAST")
-class EnumDecoder<T : Any>(private val ignoreCase: Boolean = false) : NullHandlingDecoder<T> {
+class EnumDecoder<T : Any> : NullHandlingDecoder<T> {
 
   override fun supports(type: KType): Boolean = type.classifier is KClass<*> && (type.classifier as KClass<*>).java.isEnum
 
@@ -26,7 +26,9 @@ class EnumDecoder<T : Any>(private val ignoreCase: Boolean = false) : NullHandli
     val klass = type.classifier as KClass<*>
 
     fun decode(value: String): ConfigResult<T> {
-      val t = klass.java.enumConstants.find { it.toString().contentEquals(value, ignoreCase) }
+      val t = klass.java.enumConstants.find {
+        it.toString().contentEquals(other = value, ignoreCase = context.config.resolveTypesCaseInsensitive)
+      }
       return if (t == null)
         ConfigFailure.InvalidEnumConstant(node, type, value).invalid()
       else

--- a/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/internal/ConfigParser.kt
+++ b/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/internal/ConfigParser.kt
@@ -18,9 +18,9 @@ import com.sksamuel.hoplite.parsers.ParserRegistry
 import com.sksamuel.hoplite.preprocessor.Preprocessor
 import com.sksamuel.hoplite.report.Print
 import com.sksamuel.hoplite.report.Reporter
-import com.sksamuel.hoplite.resolver.context.ContextResolverMode
 import com.sksamuel.hoplite.resolver.Resolver
 import com.sksamuel.hoplite.resolver.Resolving
+import com.sksamuel.hoplite.resolver.context.ContextResolverMode
 import com.sksamuel.hoplite.secrets.Obfuscator
 import com.sksamuel.hoplite.secrets.SecretsPolicy
 import kotlin.reflect.KClass
@@ -37,6 +37,7 @@ class ConfigParser(
    private val decoderRegistry: DecoderRegistry,
    private val paramMappers: List<ParameterMapper>,
    private val flattenArraysToString: Boolean,
+   private val resolveTypesCaseInsensitive: Boolean,
    private val allowUnresolvedSubstitutions: Boolean,
    private val secretsPolicy: SecretsPolicy?,
    private val decodeMode: DecodeMode,
@@ -57,7 +58,7 @@ class ConfigParser(
     return DecoderContext(
       decoders = decoderRegistry,
       paramMappers = paramMappers,
-      config = DecoderConfig(flattenArraysToString),
+      config = DecoderConfig(flattenArraysToString, resolveTypesCaseInsensitive),
       environment = environment,
       resolvers = Resolving(resolvers, root),
       sealedTypeDiscriminatorField = sealedTypeDiscriminatorField,

--- a/hoplite-core/src/test/kotlin/com/sksamuel/hoplite/decoder/EnumDecoderTest.kt
+++ b/hoplite-core/src/test/kotlin/com/sksamuel/hoplite/decoder/EnumDecoderTest.kt
@@ -56,6 +56,30 @@ class EnumDecoderTest : BehaviorSpec({
       }
     }
   }
+
+  given("an enum decoder ignoring case") {
+    val decoder = EnumDecoder<TestEnum>(ignoreCase = true)
+
+    `when`("checking it's priority") {
+      val actual = decoder.priority()
+
+      then("should return 0") {
+        actual shouldBe 0
+      }
+    }
+  }
+
+  given("an enum decoder respecting case") {
+    val decoder = EnumDecoder<TestEnum>(ignoreCase = false)
+
+    `when`("checking it's priority") {
+      val actual = decoder.priority()
+
+      then("should return -100") {
+        actual shouldBe -100
+      }
+    }
+  }
 }) {
   private companion object {
     fun <T : Any> EnumDecoder<T>.decode(node: PrimitiveNode) = decode(

--- a/hoplite-core/src/test/kotlin/com/sksamuel/hoplite/decoder/EnumDecoderTest.kt
+++ b/hoplite-core/src/test/kotlin/com/sksamuel/hoplite/decoder/EnumDecoderTest.kt
@@ -1,0 +1,71 @@
+package com.sksamuel.hoplite.decoder
+
+import com.sksamuel.hoplite.ConfigFailure
+import com.sksamuel.hoplite.DecoderContext
+import com.sksamuel.hoplite.Pos
+import com.sksamuel.hoplite.PrimitiveNode
+import com.sksamuel.hoplite.StringNode
+import com.sksamuel.hoplite.defaultParamMappers
+import com.sksamuel.hoplite.fp.Validated
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlin.reflect.full.createType
+
+class EnumDecoderTest : BehaviorSpec({
+
+  given("a value matching enum case") {
+    val node = StringNode("ONE", Pos.NoPos, DotPath.root)
+
+    `when`("using case sensitive decoding") {
+      val actual = EnumDecoder<TestEnum>(ignoreCase = false).decode(node)
+
+      then("should decode it") {
+        actual.shouldBeInstanceOf<Validated.Valid<TestEnum>>()
+          .value shouldBe TestEnum.ONE
+      }
+    }
+
+    `when`("using case insensitive decoding") {
+      val actual = EnumDecoder<TestEnum>(ignoreCase = true).decode(node)
+
+      then("should decode it") {
+        actual.shouldBeInstanceOf<Validated.Valid<TestEnum>>()
+          .value shouldBe TestEnum.ONE
+      }
+    }
+  }
+
+  given("a value not matching enum case") {
+    val node = StringNode("Two", Pos.NoPos, DotPath.root)
+
+    `when`("using case sensitive decoding") {
+      val actual = EnumDecoder<TestEnum>(ignoreCase = false).decode(node)
+
+      then("should return error") {
+        actual.shouldBeInstanceOf<Validated.Invalid<ConfigFailure>>()
+      }
+    }
+
+    `when`("using case insensitive decoding") {
+      val actual = EnumDecoder<TestEnum>(ignoreCase = true).decode(node)
+
+      then("should decode it") {
+        actual.shouldBeInstanceOf<Validated.Valid<TestEnum>>()
+          .value shouldBe TestEnum.TWO
+      }
+    }
+  }
+}) {
+  private companion object {
+    fun <T : Any> EnumDecoder<T>.decode(node: PrimitiveNode) = decode(
+      node,
+      TestEnum::class.createType(),
+      DecoderContext(defaultDecoderRegistry(), defaultParamMappers())
+    )
+
+    enum class TestEnum {
+      ONE, TWO
+    }
+  }
+}

--- a/hoplite-core/src/test/kotlin/com/sksamuel/hoplite/decoder/EnumDecoderTest.kt
+++ b/hoplite-core/src/test/kotlin/com/sksamuel/hoplite/decoder/EnumDecoderTest.kt
@@ -1,6 +1,7 @@
 package com.sksamuel.hoplite.decoder
 
 import com.sksamuel.hoplite.ConfigFailure
+import com.sksamuel.hoplite.DecoderConfig
 import com.sksamuel.hoplite.DecoderContext
 import com.sksamuel.hoplite.Pos
 import com.sksamuel.hoplite.PrimitiveNode
@@ -18,7 +19,7 @@ class EnumDecoderTest : BehaviorSpec({
     val node = StringNode("ONE", Pos.NoPos, DotPath.root)
 
     `when`("using case sensitive decoding") {
-      val actual = EnumDecoder<TestEnum>(ignoreCase = false).decode(node)
+      val actual = EnumDecoder<TestEnum>().decode(node, ignoreCase = false)
 
       then("should decode it") {
         actual.shouldBeInstanceOf<Validated.Valid<TestEnum>>()
@@ -27,7 +28,7 @@ class EnumDecoderTest : BehaviorSpec({
     }
 
     `when`("using case insensitive decoding") {
-      val actual = EnumDecoder<TestEnum>(ignoreCase = true).decode(node)
+      val actual = EnumDecoder<TestEnum>().decode(node, ignoreCase = true)
 
       then("should decode it") {
         actual.shouldBeInstanceOf<Validated.Valid<TestEnum>>()
@@ -40,7 +41,7 @@ class EnumDecoderTest : BehaviorSpec({
     val node = StringNode("Two", Pos.NoPos, DotPath.root)
 
     `when`("using case sensitive decoding") {
-      val actual = EnumDecoder<TestEnum>(ignoreCase = false).decode(node)
+      val actual = EnumDecoder<TestEnum>().decode(node, ignoreCase = false)
 
       then("should return error") {
         actual.shouldBeInstanceOf<Validated.Invalid<ConfigFailure>>()
@@ -48,7 +49,7 @@ class EnumDecoderTest : BehaviorSpec({
     }
 
     `when`("using case insensitive decoding") {
-      val actual = EnumDecoder<TestEnum>(ignoreCase = true).decode(node)
+      val actual = EnumDecoder<TestEnum>().decode(node, ignoreCase = true)
 
       then("should decode it") {
         actual.shouldBeInstanceOf<Validated.Valid<TestEnum>>()
@@ -58,10 +59,14 @@ class EnumDecoderTest : BehaviorSpec({
   }
 }) {
   private companion object {
-    fun <T : Any> EnumDecoder<T>.decode(node: PrimitiveNode) = decode(
+    fun <T : Any> EnumDecoder<T>.decode(node: PrimitiveNode, ignoreCase: Boolean) = decode(
       node,
       TestEnum::class.createType(),
-      DecoderContext(defaultDecoderRegistry(), defaultParamMappers())
+      DecoderContext(
+        decoders = defaultDecoderRegistry(),
+        paramMappers = defaultParamMappers(),
+        config = DecoderConfig(flattenArraysToString = false, resolveTypesCaseInsensitive = ignoreCase)
+      )
     )
 
     enum class TestEnum {

--- a/hoplite-core/src/test/kotlin/com/sksamuel/hoplite/decoder/EnumDecoderTest.kt
+++ b/hoplite-core/src/test/kotlin/com/sksamuel/hoplite/decoder/EnumDecoderTest.kt
@@ -56,30 +56,6 @@ class EnumDecoderTest : BehaviorSpec({
       }
     }
   }
-
-  given("an enum decoder ignoring case") {
-    val decoder = EnumDecoder<TestEnum>(ignoreCase = true)
-
-    `when`("checking it's priority") {
-      val actual = decoder.priority()
-
-      then("should return 0") {
-        actual shouldBe 0
-      }
-    }
-  }
-
-  given("an enum decoder respecting case") {
-    val decoder = EnumDecoder<TestEnum>(ignoreCase = false)
-
-    `when`("checking it's priority") {
-      val actual = decoder.priority()
-
-      then("should return -100") {
-        actual shouldBe -100
-      }
-    }
-  }
 }) {
   private companion object {
     fun <T : Any> EnumDecoder<T>.decode(node: PrimitiveNode) = decode(

--- a/hoplite-yaml/src/test/kotlin/com/sksamuel/hoplite/decoder/EnumDecoderTest.kt
+++ b/hoplite-yaml/src/test/kotlin/com/sksamuel/hoplite/decoder/EnumDecoderTest.kt
@@ -1,0 +1,48 @@
+package com.sksamuel.hoplite.decoder
+
+import com.sksamuel.hoplite.ConfigFailure
+import com.sksamuel.hoplite.ConfigLoaderBuilder
+import com.sksamuel.hoplite.fp.Validated
+import io.kotest.assertions.asClue
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+class EnumDecoderTest : BehaviorSpec({
+
+  data class Test(val a: Wine, val b: Wine)
+
+  given("yml file with invalid enum name case") {
+    val yaml = "/enums.yml"
+
+    `when`("using case sensitive decoding") {
+      val config = ConfigLoaderBuilder.default()
+        .build()
+        .loadConfig<Test>(yaml)
+
+      then("should return an error") {
+        config.shouldBeInstanceOf<Validated.Invalid<ConfigFailure>>()
+          .error.shouldBeInstanceOf<ConfigFailure.DataClassFieldErrors>()
+          .errors.list.shouldHaveSize(1)
+          .first().shouldBeInstanceOf<ConfigFailure.ParamFailure>()
+          .error.shouldBeInstanceOf<ConfigFailure.InvalidEnumConstant>()
+      }
+    }
+
+    `when`("using case insensitive decoding") {
+      val config = ConfigLoaderBuilder.default()
+        .withResolveTypesCaseInsensitive()
+        .build()
+        .loadConfig<Test>(yaml)
+
+      then("should load the config") {
+        config.shouldBeInstanceOf<Validated.Valid<Test>>()
+          .value.asClue {
+            it.a shouldBe Wine.Malbec
+            it.b shouldBe Wine.Merlot
+          }
+      }
+    }
+  }
+})

--- a/hoplite-yaml/src/test/resources/enums.yml
+++ b/hoplite-yaml/src/test/resources/enums.yml
@@ -1,0 +1,2 @@
+a: Malbec
+b: MERLOT


### PR DESCRIPTION
Adds support for case insensitive decoding of enums to `EnumDecoder`