### PR TITLE
Fix loadConfigOrThrow example in README to have a leading forward slash

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ There are convenience methods on `ConfigLoaderBuilder` to construct `ConfigFileP
 For example, the following are equivalent:
 
 ```kotlin
-ConfigLoader().loadConfigOrThrow<MyConfig>("config.json")
+ConfigLoader().loadConfigOrThrow<MyConfig>("/config.json")
 ```
 
 and


### PR DESCRIPTION
When using version `2.7.5` of hoplite-hocon, it seems like a leading forward slash is required before the filename.

i.e this does not work for me:

```
    ConfigLoader().loadConfigOrThrow("application.conf")
```
```
Exception in thread "main" com.sksamuel.hoplite.ConfigException: Error loading config because:
    Could not find application.conf
```

but this works:

```
    ConfigLoader().loadConfigOrThrow("/application.conf")
```

I see all of the other examples in the README have a leading forward slash.