### PR TITLE
Target JVM 8 instead of JVM 11 for wider support

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -42,7 +42,7 @@ allprojects {
    }
 
    tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
-      kotlinOptions.jvmTarget = "11"
+      kotlinOptions.jvmTarget = "1.8"
    }
 
    java {


### PR DESCRIPTION
As there is actually no expense involved from developers to support JVM 8 in Kotlin, it sounds reasonable to do so, as that is still a supported and widely used java version.

The only change necessary in this case is to change the `jvmTarget` kotlin option.

We should not change the java toolchain version, as some test dependencies require java 11 or higher. It does not affect the target version against which we compile anyway. For same reason there is no need to touch the git actions configuration.