### PR TITLE
build: Set compileJava target and source compatability to 1.8

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -51,6 +51,11 @@ allprojects {
       }
    }
 
+   tasks.compileJava {
+      targetCompatibility = "1.8"
+      sourceCompatibility = "1.8"
+   }
+
    repositories {
       mavenLocal()
       mavenCentral()


### PR DESCRIPTION
That is another PR for the Java 8 support. So far the code is already being compiled for Java 8, but as Gradle uses compileJava compatability over the Kotlin's jvmTarget, we have to additionally explicitly set these to the proper version.