### PR TITLE
Add type to missing config message

### DIFF
--- a/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/ConfigFailure.kt
+++ b/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/ConfigFailure.kt
@@ -231,7 +231,7 @@ sealed interface ConfigFailure {
   }
 
   data class MissingConfigValue(val type: KType) : ConfigFailure {
-    override fun description(): String = "Missing from config"
+    override fun description(): String = "Missing ${type.simpleName} from config"
   }
 
   data class Generic(val msg: String) : ConfigFailure {


### PR DESCRIPTION
The missing config value description was not helpful. Add the missing type name.