### PR TITLE
Support loading configs via prefix

### DIFF
--- a/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/internal/ConfigParser.kt
+++ b/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/internal/ConfigParser.kt
@@ -33,6 +33,7 @@ class ConfigParser(
    cascadeMode: CascadeMode,
    preprocessors: List<Preprocessor>,
    preprocessingIterations: Int,
+   private val prefix: String?,
    private val resolvers: List<Resolver>,
    private val decoderRegistry: DecoderRegistry,
    private val paramMappers: List<ParameterMapper>,
@@ -81,10 +82,10 @@ class ConfigParser(
       cascader.cascade(nodes).flatMap { node ->
         val context = context(node)
         preprocessing.preprocess(node, context).flatMap { preprocessed ->
-          check(preprocessed).flatMap {
+          check(preprocessed.let { if (prefix == null) it else it.atPath(prefix) }).flatMap {
 
-            val decoded = decoding.decode(kclass, preprocessed, decodeMode, context)
-            val state = createDecodingState(preprocessed, context, secretsPolicy)
+            val decoded = decoding.decode(kclass, it, decodeMode, context)
+            val state = createDecodingState(it, context, secretsPolicy)
 
             // always do report regardless of decoder result
             if (useReport) {

--- a/hoplite-core/src/test/kotlin/com/sksamuel/hoplite/PrefixTest.kt
+++ b/hoplite-core/src/test/kotlin/com/sksamuel/hoplite/PrefixTest.kt
@@ -1,0 +1,152 @@
+package com.sksamuel.hoplite
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.extensions.system.withEnvironment
+import io.kotest.matchers.shouldBe
+
+class PrefixTest : FunSpec() {
+  init {
+
+    test("reads config from string at a given prefix") {
+      data class TestConfig(val a: String, val b: Int)
+
+      val config = ConfigLoaderBuilder.default()
+        .addPropertySource(
+          PropertySource.string(
+            """
+          foo.a = A value
+          foo.b = 42
+          bar.a = A value bar
+          bar.b = 45
+          """.trimIndent(), "props"
+          )
+        )
+        .build()
+        .loadConfigOrThrow<TestConfig>(prefix = "foo")
+
+      config shouldBe TestConfig("A value", 42)
+    }
+
+    test("reads config from input stream at a given prefix") {
+      data class TestConfig(val a: String, val b: Int)
+
+      val stream = """
+          foo.a = A value
+          foo.b = 42
+          bar.a = A value bar
+          bar.b = 45
+          """.trimIndent().byteInputStream(Charsets.UTF_8)
+
+      val config = ConfigLoaderBuilder.default()
+        .addPropertySource(PropertySource.stream(stream, "props"))
+        .build()
+        .loadConfigOrThrow<TestConfig>(prefix = "foo")
+
+      config shouldBe TestConfig("A value", 42)
+    }
+
+    test("reads config from map at a given prefix") {
+      data class TestConfig(val a: String, val b: Int, val other: List<String>)
+
+      val arguments = mapOf(
+        "foo.a" to "A value",
+        "foo.b" to "42",
+        "bar.a" to "A value bar",
+        "bar.b" to "45",
+        "foo.other" to listOf("Value1", "Value2"),
+        "bar.other" to listOf("Value1bar", "Value2bar")
+      )
+
+      val config = ConfigLoaderBuilder.default()
+        .addPropertySource(PropertySource.map(arguments))
+        .build()
+        .loadConfigOrThrow<TestConfig>(prefix = "foo")
+
+      config shouldBe TestConfig("A value", 42, listOf("Value1", "Value2"))
+    }
+
+    test("reads config from command line at a given prefix") {
+      data class TestConfig(val a: String, val b: Int, val other: List<String>)
+
+      val arguments = arrayOf(
+        "--foo.a=A value",
+        "--foo.b=42",
+        "--bar.a=A value bar",
+        "--bar.b=45",
+        "some other value",
+        "--foo.other=Value1",
+        "--foo.other=Value2",
+        "--bar.other=Value1bar",
+        "--bar.other=Value2bar",
+        "--other=Value1o",
+        "--other=Value2o"
+      )
+
+      val config = ConfigLoaderBuilder.default()
+        .addPropertySource(PropertySource.commandLine(arguments))
+        .build()
+        .loadConfigOrThrow<TestConfig>(prefix = "foo")
+
+      config shouldBe TestConfig("A value", 42, listOf("Value1", "Value2"))
+    }
+
+    test("reads from added source before default sources at a given prefix") {
+      data class TestConfig(val a: String, val b: Int, val other: List<String>)
+
+      withEnvironment(mapOf("foo.b" to "91", "foo.other" to "Random13")) {
+
+        val arguments = arrayOf(
+          "--foo.a=A value",
+          "--foo.b=42",
+          "--bar.a=A value bar",
+          "--bar.b=45",
+          "some other value",
+          "--foo.other=Value1",
+          "--foo.other=Value2",
+          "--bar.other=Value1bar",
+          "--bar.other=Value2bar",
+          "--other=Value1o",
+          "--other=Value2o"
+        )
+
+        val config = ConfigLoaderBuilder.default()
+          .addPropertySource(PropertySource.commandLine(arguments))
+          .addDefaultPropertySources()
+          .addEnvironmentSource()
+          .build()
+          .loadConfigOrThrow<TestConfig>(prefix = "foo")
+
+        config shouldBe TestConfig("A value", 42, listOf("Value1", "Value2"))
+      }
+    }
+
+    test("reads from default source before specified at a given prefix") {
+      data class TestConfig(val a: String, val b: Int, val other: List<String>)
+
+      withEnvironment(mapOf("foo.b" to "91", "foo.other" to "Random13")) {
+        val arguments = arrayOf(
+          "--foo.a=A value",
+          "--foo.b=42",
+          "--bar.a=A value bar",
+          "--bar.b=45",
+          "some other value",
+          "--foo.other=Value1",
+          "--foo.other=Value2",
+          "--bar.other=Value1bar",
+          "--bar.other=Value2bar",
+          "--other=Value1o",
+          "--other=Value2o"
+        )
+
+        val config = ConfigLoaderBuilder.default()
+          .addEnvironmentSource()
+          .addDefaultPropertySources()
+          .addPropertySource(PropertySource.commandLine(arguments))
+          .build()
+          .loadConfigOrThrow<TestConfig>(prefix = "foo")
+
+        config shouldBe TestConfig("A value", 91, listOf("Random13"))
+      }
+    }
+  }
+}

--- a/hoplite-json/src/test/kotlin/com/sksamuel/hoplite/json/ErrorTests.kt
+++ b/hoplite-json/src/test/kotlin/com/sksamuel/hoplite/json/ErrorTests.kt
@@ -34,7 +34,7 @@ class ErrorTests : StringSpec({
 
         - 'wrongType': Required type Boolean could not be decoded from a Long value: 123 (classpath:/error1.json:2:19)
 
-        - 'whereAmI': Missing from config
+        - 'whereAmI': Missing String from config
 
         - 'notnull': Type defined as not-null but null was loaded from config (classpath:/error1.json:6:18)
 

--- a/hoplite-yaml/src/test/kotlin/com/sksamuel/hoplite/yaml/CollectionErrorTest.kt
+++ b/hoplite-yaml/src/test/kotlin/com/sksamuel/hoplite/yaml/CollectionErrorTest.kt
@@ -27,7 +27,7 @@ class CollectionErrorTests : StringSpec({
 
                     - Could not instantiate 'com.sksamuel.hoplite.yaml.Parser' because:
 
-                        - 'id': Missing from config
+                        - 'id': Missing String from config
 
             - Could not instantiate 'com.sksamuel.hoplite.yaml.Supplier' because:
 
@@ -35,7 +35,7 @@ class CollectionErrorTests : StringSpec({
 
                     - Could not instantiate 'com.sksamuel.hoplite.yaml.Parser' because:
 
-                        - 'id': Missing from config
+                        - 'id': Missing String from config
 
             - Could not instantiate 'com.sksamuel.hoplite.yaml.Supplier' because:
 
@@ -43,6 +43,6 @@ class CollectionErrorTests : StringSpec({
 
                     - Could not instantiate 'com.sksamuel.hoplite.yaml.Parser' because:
 
-                        - 'id': Missing from config"""
+                        - 'id': Missing String from config"""
   }
 })


### PR DESCRIPTION
I've taken a shot at updating Hoplite with prefix support. There is more to do on this PR (like tests), but I wanted to get some early feedback on this general approach.

This still loads everything once per prefix (and outputs multiple reports), but I think that is fine for this iteration, and we can consider a "load once and extract prefixes multiple times" improvement in a subsequent PR.

Also, I did not implement this as a `Preprocessor` [as in this post](https://github.com/sksamuel/hoplite/issues/386#issuecomment-2019937200) because I don't want the dependency on the prefix to exist at `ConfigLoaderBuilder` time, but only at load time. This should make it easier to later just do the loading once, instead of once per prefix.

This would resolve https://github.com/sksamuel/hoplite/issues/386.