### PR TITLE
Path normalization via new `NodeTransformer` interface

### DIFF
--- a/hoplite-aws/src/main/kotlin/com/sksamuel/hoplite/aws/ParameterStorePathPropertySource.kt
+++ b/hoplite-aws/src/main/kotlin/com/sksamuel/hoplite/aws/ParameterStorePathPropertySource.kt
@@ -10,7 +10,6 @@ import com.sksamuel.hoplite.PropertySource
 import com.sksamuel.hoplite.PropertySourceContext
 import com.sksamuel.hoplite.decoder.toValidated
 import com.sksamuel.hoplite.parsers.toNode
-import java.util.Properties
 
 /**
  * Provides all keys under a prefix path as config values.
@@ -47,12 +46,9 @@ class ParameterStorePathPropertySource(
 
   override fun node(context: PropertySourceContext): ConfigResult<Node> {
     return fetchParameterStoreValues().map { params ->
-      val props = Properties()
-      params.forEach {
-        val name = if (stripPath) it.name.removePrefix(prefix) else it.name
-        props[name.removePrefix("/")] = it.value
+      params.associate { it.name to it.value }.toNode("aws_parameter_store at $prefix", "/") {
+        (if (stripPath) it.removePrefix(prefix) else it).removePrefix("/")
       }
-      props.toNode("aws_parameter_store at $prefix", "/")
     }.toValidated {
       ConfigFailure.PropertySourceFailure("Could not fetch data from AWS parameter store: ${it.message}", it)
     }

--- a/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/ConfigFailure.kt
+++ b/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/ConfigFailure.kt
@@ -1,7 +1,6 @@
 package com.sksamuel.hoplite
 
 import com.sksamuel.hoplite.decoder.Decoder
-import com.sksamuel.hoplite.decoder.DotPath
 import com.sksamuel.hoplite.fp.NonEmptyList
 import com.sksamuel.hoplite.internal.OverridePath
 import com.sksamuel.hoplite.parsers.Parser
@@ -30,9 +29,9 @@ sealed interface ConfigFailure {
    */
   fun description(): String
 
-  data class UnusedPath(val path: DotPath, val pos: Pos) : ConfigFailure {
+  data class UnusedPath(val decodedPath: DecodedPath) : ConfigFailure {
     override fun description(): String {
-      return "Config value '${path.flatten()}' at ${pos.loc()} was unused"
+      return "Config value '${decodedPath.sourceKey ?: decodedPath.path.flatten()}' at ${decodedPath.pos.loc()} was unused"
     }
   }
 

--- a/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/ConfigLoader.kt
+++ b/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/ConfigLoader.kt
@@ -9,6 +9,7 @@ import com.sksamuel.hoplite.fp.getOrElse
 import com.sksamuel.hoplite.internal.CascadeMode
 import com.sksamuel.hoplite.internal.ConfigParser
 import com.sksamuel.hoplite.internal.DecodeMode
+import com.sksamuel.hoplite.transformer.NodeTransformer
 import com.sksamuel.hoplite.parsers.ParserRegistry
 import com.sksamuel.hoplite.preprocessor.Preprocessor
 import com.sksamuel.hoplite.report.Print
@@ -27,6 +28,7 @@ class ConfigLoader(
   val propertySources: List<PropertySource>,
   val parserRegistry: ParserRegistry,
   val preprocessors: List<Preprocessor>,
+  val nodeTransformers: List<NodeTransformer>,
   val paramMappers: List<ParameterMapper>,
   val onFailure: List<(Throwable) -> Unit> = emptyList(),
   val decodeMode: DecodeMode = DecodeMode.Lenient,
@@ -195,6 +197,7 @@ class ConfigLoader(
       cascadeMode = cascadeMode,
       preprocessors = preprocessors,
       preprocessingIterations = preprocessingIterations,
+      nodeTransformers = nodeTransformers,
       prefix = prefix,
       resolvers = resolvers,
       decoderRegistry = decoderRegistry,
@@ -251,6 +254,7 @@ class ConfigLoader(
       cascadeMode = cascadeMode,
       preprocessors = preprocessors,
       preprocessingIterations = preprocessingIterations,
+      nodeTransformers = nodeTransformers,
       prefix = null,
       resolvers = resolvers,
       decoderRegistry = decoderRegistry,

--- a/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/ConfigLoaderBuilder.kt
+++ b/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/ConfigLoaderBuilder.kt
@@ -31,6 +31,7 @@ import com.sksamuel.hoplite.sources.EnvironmentVariableOverridePropertySource
 import com.sksamuel.hoplite.sources.SystemPropertiesPropertySource
 import com.sksamuel.hoplite.sources.UserSettingsPropertySource
 import com.sksamuel.hoplite.sources.XdgConfigPropertySource
+import com.sksamuel.hoplite.transformer.PathNormalizer
 import java.util.ServiceLoader
 
 class ConfigLoaderBuilder private constructor() {
@@ -423,7 +424,9 @@ fun defaultPreprocessors(): List<Preprocessor> = listOf(
   LookupPreprocessor,
 )
 
-fun defaultNodeTransformers(): List<NodeTransformer> = emptyList()
+fun defaultNodeTransformers(): List<NodeTransformer> = listOf(
+  PathNormalizer,
+)
 
 fun defaultResolvers(): List<Resolver> = listOf(
   EnvVarContextResolver,
@@ -438,8 +441,6 @@ fun defaultResolvers(): List<Resolver> = listOf(
 fun defaultParamMappers(): List<ParameterMapper> = listOf(
   DefaultParamMapper,
   LowercaseParamMapper,
-  SnakeCaseParamMapper,
-  KebabCaseParamMapper,
   AliasAnnotationParamMapper,
 )
 

--- a/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/DecoderContext.kt
+++ b/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/DecoderContext.kt
@@ -75,3 +75,9 @@ data class DecoderConfig(
   val flattenArraysToString: Boolean,
   val resolveTypesCaseInsensitive: Boolean,
 )
+
+data class DecodedPath(
+  val path: DotPath,
+  val sourceKey: String?,
+  val pos: Pos,
+)

--- a/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/ParameterMapper.kt
+++ b/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/ParameterMapper.kt
@@ -62,6 +62,8 @@ object AliasAnnotationParamMapper : ParameterMapper {
  * the snake case equivalent.
  *
  * For example, camelCasePilsen will become snake_case_pilsen.
+ *
+ * When using the [PathNormalizer] (which is enabled by default), this mapper is unnecessary.
  */
 object SnakeCaseParamMapper : ParameterMapper {
 
@@ -86,6 +88,8 @@ object SnakeCaseParamMapper : ParameterMapper {
  * the kebab case equivalent.
  *
  * For example, camelCasePilsen will become kebab-case-pilsen.
+ *
+ * When using the [PathNormalizer] (which is enabled by default), this mapper is unnecessary.
  */
 object KebabCaseParamMapper : ParameterMapper {
 

--- a/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/ParameterMapper.kt
+++ b/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/ParameterMapper.kt
@@ -34,6 +34,11 @@ object DefaultParamMapper : ParameterMapper {
     setOfNotNull(param.name)
 }
 
+object LowercaseParamMapper : ParameterMapper {
+  override fun map(param: KParameter, constructor: KFunction<Any>, kclass: KClass<*>): Set<String> =
+    setOfNotNull(param.name?.lowercase())
+}
+
 /**
  * Disabled by default so that common ENVVAR PARAMS don't override your lower case
  * names unexpectedly.

--- a/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/decoder/AbstractUnnormalizedKeysDecoder.kt
+++ b/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/decoder/AbstractUnnormalizedKeysDecoder.kt
@@ -1,0 +1,33 @@
+package com.sksamuel.hoplite.decoder
+
+import com.sksamuel.hoplite.ConfigResult
+import com.sksamuel.hoplite.DecoderContext
+import com.sksamuel.hoplite.MapNode
+import com.sksamuel.hoplite.Node
+import com.sksamuel.hoplite.transform
+import kotlin.reflect.KType
+
+/**
+ * A decoder which decodes based on unnormalized keys.
+ *
+ * This is useful for decoders that need to know the original key names.
+ *
+ * It restores the original key names from the node source key.
+ */
+abstract class AbstractUnnormalizedKeysDecoder<T> : NullHandlingDecoder<T> {
+  override fun safeDecode(node: Node, type: KType, context: DecoderContext): ConfigResult<T> {
+    val unnormalizedNode = node.transform {
+      val sourceKey = it.sourceKey
+      when (it) {
+        is MapNode -> it.copy(map = it.map.mapKeys { (k, v) ->
+          (v.sourceKey ?: k).removePrefix("$sourceKey.")
+        })
+        else -> it
+      }
+    }
+
+    return safeDecodeUnnormalized(unnormalizedNode, type, context)
+  }
+
+  abstract fun safeDecodeUnnormalized(node: Node, type: KType, context: DecoderContext): ConfigResult<T>
+}

--- a/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/decoder/MapDecoder.kt
+++ b/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/decoder/MapDecoder.kt
@@ -15,15 +15,13 @@ import kotlin.reflect.full.isSubtypeOf
 import kotlin.reflect.full.starProjectedType
 import kotlin.reflect.full.withNullability
 
-class MapDecoder : NullHandlingDecoder<Map<*, *>> {
+class MapDecoder : AbstractUnnormalizedKeysDecoder<Map<*, *>>() {
 
   override fun supports(type: KType): Boolean =
     type.isSubtypeOf(Map::class.starProjectedType) ||
       type.isSubtypeOf(Map::class.starProjectedType.withNullability(true))
 
-  override fun safeDecode(node: Node,
-                          type: KType,
-                          context: DecoderContext): ConfigResult<Map<*, *>> {
+  override fun safeDecodeUnnormalized(node: Node, type: KType, context: DecoderContext): ConfigResult<Map<*, *>> {
     require(type.arguments.size == 2)
 
     val kType = type.arguments[0].type!!

--- a/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/internal/ConfigParser.kt
+++ b/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/internal/ConfigParser.kt
@@ -53,7 +53,7 @@ class ConfigParser(
   private val contextResolverMode: ContextResolverMode,
 ) {
 
-  private val loader = PropertySourceLoader(nodeTransformers, classpathResourceLoader, parserRegistry, allowEmptyTree)
+  private val loader = PropertySourceLoader(nodeTransformers, sealedTypeDiscriminatorField, classpathResourceLoader, parserRegistry, allowEmptyTree)
   private val cascader = Cascader(cascadeMode, allowEmptyTree, allowNullOverride)
   private val preprocessing = Preprocessing(preprocessors, preprocessingIterations)
   private val decoding = Decoding(decoderRegistry, secretsPolicy)

--- a/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/internal/ConfigParser.kt
+++ b/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/internal/ConfigParser.kt
@@ -14,6 +14,7 @@ import com.sksamuel.hoplite.env.Environment
 import com.sksamuel.hoplite.fp.flatMap
 import com.sksamuel.hoplite.fp.invalid
 import com.sksamuel.hoplite.fp.valid
+import com.sksamuel.hoplite.transformer.NodeTransformer
 import com.sksamuel.hoplite.parsers.ParserRegistry
 import com.sksamuel.hoplite.preprocessor.Preprocessor
 import com.sksamuel.hoplite.report.Print
@@ -23,34 +24,36 @@ import com.sksamuel.hoplite.resolver.Resolving
 import com.sksamuel.hoplite.resolver.context.ContextResolverMode
 import com.sksamuel.hoplite.secrets.Obfuscator
 import com.sksamuel.hoplite.secrets.SecretsPolicy
+import com.sksamuel.hoplite.transformer.PathNormalizer
 import kotlin.reflect.KClass
 
 class ConfigParser(
-   classpathResourceLoader: ClasspathResourceLoader,
-   parserRegistry: ParserRegistry,
-   allowEmptyTree: Boolean,
-   allowNullOverride: Boolean,
-   cascadeMode: CascadeMode,
-   preprocessors: List<Preprocessor>,
-   preprocessingIterations: Int,
-   private val prefix: String?,
-   private val resolvers: List<Resolver>,
-   private val decoderRegistry: DecoderRegistry,
-   private val paramMappers: List<ParameterMapper>,
-   private val flattenArraysToString: Boolean,
-   private val resolveTypesCaseInsensitive: Boolean,
-   private val allowUnresolvedSubstitutions: Boolean,
-   private val secretsPolicy: SecretsPolicy?,
-   private val decodeMode: DecodeMode,
-   private val useReport: Boolean,
-   private val obfuscator: Obfuscator,
-   private val reportPrintFn: Print,
-   private val environment: Environment?,
-   private val sealedTypeDiscriminatorField: String?,
-   private val contextResolverMode: ContextResolverMode,
+  classpathResourceLoader: ClasspathResourceLoader,
+  parserRegistry: ParserRegistry,
+  allowEmptyTree: Boolean,
+  allowNullOverride: Boolean,
+  cascadeMode: CascadeMode,
+  preprocessors: List<Preprocessor>,
+  preprocessingIterations: Int,
+  private val nodeTransformers: List<NodeTransformer>,
+  private val prefix: String?,
+  private val resolvers: List<Resolver>,
+  private val decoderRegistry: DecoderRegistry,
+  private val paramMappers: List<ParameterMapper>,
+  private val flattenArraysToString: Boolean,
+  private val resolveTypesCaseInsensitive: Boolean,
+  private val allowUnresolvedSubstitutions: Boolean,
+  private val secretsPolicy: SecretsPolicy?,
+  private val decodeMode: DecodeMode,
+  private val useReport: Boolean,
+  private val obfuscator: Obfuscator,
+  private val reportPrintFn: Print,
+  private val environment: Environment?,
+  private val sealedTypeDiscriminatorField: String?,
+  private val contextResolverMode: ContextResolverMode,
 ) {
 
-  private val loader = PropertySourceLoader(classpathResourceLoader, parserRegistry, allowEmptyTree)
+  private val loader = PropertySourceLoader(nodeTransformers, classpathResourceLoader, parserRegistry, allowEmptyTree)
   private val cascader = Cascader(cascadeMode, allowEmptyTree, allowNullOverride)
   private val preprocessing = Preprocessing(preprocessors, preprocessingIterations)
   private val decoding = Decoding(decoderRegistry, secretsPolicy)
@@ -82,8 +85,7 @@ class ConfigParser(
       cascader.cascade(nodes).flatMap { node ->
         val context = context(node)
         preprocessing.preprocess(node, context).flatMap { preprocessed ->
-          check(preprocessed.let { if (prefix == null) it else it.atPath(prefix) }).flatMap {
-
+          check(preprocessed.prefixedNode()).flatMap {
             val decoded = decoding.decode(kclass, it, decodeMode, context)
             val state = createDecodingState(it, context, secretsPolicy)
 
@@ -121,5 +123,11 @@ class ConfigParser(
       node.valid()
     else
       UnresolvedSubstitutionChecker.process(node)
+  }
+
+  private fun Node.prefixedNode() = when {
+    prefix == null -> this
+    nodeTransformers.contains(PathNormalizer) -> atPath(PathNormalizer.normalizePathElement(prefix))
+    else -> atPath(prefix)
   }
 }

--- a/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/internal/DecodeModeValidator.kt
+++ b/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/internal/DecodeModeValidator.kt
@@ -20,7 +20,7 @@ class DecodeModeValidator(private val mode: DecodeMode) {
 
   private fun ensureAllUsed(result: DecodingState): ConfigResult<DecodingState> {
     return if (result.unused.isEmpty()) result.valid() else {
-      val errors = NonEmptyList.unsafe(result.unused.map { ConfigFailure.UnusedPath(it.first, it.second) })
+      val errors = NonEmptyList.unsafe(result.unused.map { ConfigFailure.UnusedPath(it) })
       ConfigFailure.MultipleFailures(errors).invalid()
     }
   }

--- a/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/internal/Decoding.kt
+++ b/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/internal/Decoding.kt
@@ -1,14 +1,14 @@
 package com.sksamuel.hoplite.internal
 
 import com.sksamuel.hoplite.ConfigResult
+import com.sksamuel.hoplite.DecodedPath
 import com.sksamuel.hoplite.DecoderContext
 import com.sksamuel.hoplite.Node
 import com.sksamuel.hoplite.NodeState
-import com.sksamuel.hoplite.Pos
 import com.sksamuel.hoplite.decoder.DecoderRegistry
 import com.sksamuel.hoplite.decoder.DotPath
 import com.sksamuel.hoplite.fp.flatMap
-import com.sksamuel.hoplite.paths
+import com.sksamuel.hoplite.decodedPaths
 import com.sksamuel.hoplite.secrets.SecretsPolicy
 import com.sksamuel.hoplite.traverse
 import kotlin.reflect.KClass
@@ -35,9 +35,9 @@ internal fun createDecodingState(
   context: DecoderContext,
   secretsPolicy: SecretsPolicy?
 ): DecodingState {
-  val (used, unused) = root.paths()
-    .filterNot { it.first == DotPath.root }
-    .partition { context.usedPaths.contains(it.first) }
+  val (used, unused) = root.decodedPaths()
+    .filterNot { it.path == DotPath.root }
+    .partition { context.usedPaths.contains(it.path) }
   return DecodingState(root, used, unused, createNodeStates(root, context, secretsPolicy))
 }
 
@@ -64,7 +64,7 @@ private fun createNodeStates(
 
 data class DecodingState(
   val root: Node,
-  val used: List<Pair<DotPath, Pos>>,
-  val unused: List<Pair<DotPath, Pos>>,
+  val used: List<DecodedPath>,
+  val unused: List<DecodedPath>,
   val states: List<NodeState>
 )

--- a/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/internal/PropertySourceLoader.kt
+++ b/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/internal/PropertySourceLoader.kt
@@ -14,16 +14,18 @@ import com.sksamuel.hoplite.fp.sequence
 import com.sksamuel.hoplite.fp.valid
 import com.sksamuel.hoplite.parsers.ParserRegistry
 import com.sksamuel.hoplite.sources.ConfigFilePropertySource
+import com.sksamuel.hoplite.transform
+import com.sksamuel.hoplite.transformer.NodeTransformer
 
 /**
  * Loads [Node]s from [PropertySource]s, [ConfigSource]s, files and classpath resources.
  */
 class PropertySourceLoader(
+  private val nodeTransformers: List<NodeTransformer>,
   private val classpathResourceLoader: ClasspathResourceLoader,
   private val parserRegistry: ParserRegistry,
   private val allowEmptyPropertySources: Boolean
 ) {
-
   fun loadNodes(
     propertySources: List<PropertySource>,
     configSources: List<ConfigSource>,
@@ -45,6 +47,11 @@ class PropertySourceLoader(
   private fun loadSources(sources: List<PropertySource>): ConfigResult<NonEmptyList<Node>> {
     return sources
       .map { it.node(PropertySourceContext(parserRegistry, allowEmptyPropertySources)) }
+      .map { configResult ->
+        configResult.flatMap { node ->
+          nodeTransformers.fold(node) { acc, normalizer -> acc.transform { normalizer.transform(it) } }.valid()
+        }
+      }
       .sequence()
       .mapInvalid { ConfigFailure.MultipleFailures(it) }
       .flatMap { if (it.isEmpty()) ConfigFailure.NoSources.invalid() else NonEmptyList.unsafe(it).valid() }

--- a/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/internal/PropertySourceLoader.kt
+++ b/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/internal/PropertySourceLoader.kt
@@ -22,6 +22,7 @@ import com.sksamuel.hoplite.transformer.NodeTransformer
  */
 class PropertySourceLoader(
   private val nodeTransformers: List<NodeTransformer>,
+  private val sealedTypeDiscriminatorField: String?,
   private val classpathResourceLoader: ClasspathResourceLoader,
   private val parserRegistry: ParserRegistry,
   private val allowEmptyPropertySources: Boolean
@@ -49,7 +50,7 @@ class PropertySourceLoader(
       .map { it.node(PropertySourceContext(parserRegistry, allowEmptyPropertySources)) }
       .map { configResult ->
         configResult.flatMap { node ->
-          nodeTransformers.fold(node) { acc, normalizer -> acc.transform { normalizer.transform(it) } }.valid()
+          nodeTransformers.fold(node) { acc, normalizer -> acc.transform { normalizer.transform(it, sealedTypeDiscriminatorField) } }.valid()
         }
       }
       .sequence()

--- a/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/nodes.kt
+++ b/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/nodes.kt
@@ -16,7 +16,7 @@ sealed interface Node {
 
   /**
    * The original source key of this node without any normalization.
-   * Useful for reporting.
+   * Useful for reporting or potentially for custom decoders.
    */
   val sourceKey: String?
 
@@ -110,6 +110,15 @@ fun <T : Node> T.withMeta(key: String, value: Any?): T = when (this) {
 fun Node.paths(): Set<Pair<DotPath, Pos>> = setOf(this.path to this.pos) + when (this) {
   is ArrayNode -> this.elements.flatMap { it.paths() }
   is MapNode -> this.map.map { it.value.paths() }.flatten()
+  else -> emptySet()
+}
+
+/**
+ * Return all decoded paths recursively in this tree.
+ */
+fun Node.decodedPaths(): Set<DecodedPath> = setOf(DecodedPath(this.path, this.sourceKey, this.pos)) + when (this) {
+  is ArrayNode -> this.elements.flatMap { it.decodedPaths() }
+  is MapNode -> this.map.map { it.value.decodedPaths() }.flatten()
   else -> emptySet()
 }
 

--- a/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/nodes.kt
+++ b/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/nodes.kt
@@ -15,6 +15,12 @@ sealed interface Node {
   val path: DotPath
 
   /**
+   * The original source key of this node without any normalization.
+   * Useful for reporting.
+   */
+  val sourceKey: String?
+
+  /**
    * Returns the [PrimitiveNode] at the given key.
    * If this node is not a [MapNode] or the node contained at the
    * given key is not a primitive, or the node does not contain
@@ -126,7 +132,8 @@ data class MapNode(
   override val pos: Pos,
   override val path: DotPath,
   val value: Node = Undefined,
-  override val meta: Map<String, Any?> = emptyMap()
+  override val meta: Map<String, Any?> = emptyMap(),
+  override val sourceKey: String? = if (path == DotPath.root) null else path.flatten(),
 ) : ContainerNode() {
   override val simpleName: String = "Map"
   override fun atKey(key: String): Node = map[key] ?: Undefined
@@ -138,7 +145,8 @@ data class ArrayNode(
   val elements: List<Node>,
   override val pos: Pos,
   override val path: DotPath,
-  override val meta: Map<String, Any?> = emptyMap()
+  override val meta: Map<String, Any?> = emptyMap(),
+  override val sourceKey: String? = if (path == DotPath.root) null else path.flatten(),
 ) : ContainerNode() {
   override val simpleName: String = "List"
   override fun atKey(key: String): Node = Undefined
@@ -157,7 +165,8 @@ data class StringNode(
   override val value: String,
   override val pos: Pos,
   override val path: DotPath,
-  override val meta: Map<String, Any?> = emptyMap()
+  override val meta: Map<String, Any?> = emptyMap(),
+  override val sourceKey: String? = if (path == DotPath.root) null else path.flatten(),
 ) : PrimitiveNode() {
   override val simpleName: String = "String"
 }
@@ -166,7 +175,8 @@ data class BooleanNode(
   override val value: Boolean,
   override val pos: Pos,
   override val path: DotPath,
-  override val meta: Map<String, Any?> = emptyMap()
+  override val meta: Map<String, Any?> = emptyMap(),
+  override val sourceKey: String? = if (path == DotPath.root) null else path.flatten(),
 ) : PrimitiveNode() {
   override val simpleName: String = "Boolean"
 }
@@ -177,7 +187,8 @@ data class LongNode(
   override val value: Long,
   override val pos: Pos,
   override val path: DotPath,
-  override val meta: Map<String, Any?> = emptyMap()
+  override val meta: Map<String, Any?> = emptyMap(),
+  override val sourceKey: String? = if (path == DotPath.root) null else path.flatten(),
 ) : NumberNode() {
   override val simpleName: String = "Long"
 }
@@ -186,7 +197,8 @@ data class DoubleNode(
   override val value: Double,
   override val pos: Pos,
   override val path: DotPath,
-  override val meta: Map<String, Any?> = emptyMap()
+  override val meta: Map<String, Any?> = emptyMap(),
+  override val sourceKey: String? = if (path == DotPath.root) null else path.flatten(),
 ) : NumberNode() {
   override val simpleName: String = "Double"
 }
@@ -194,7 +206,8 @@ data class DoubleNode(
 data class NullNode(
   override val pos: Pos,
   override val path: DotPath,
-  override val meta: Map<String, Any?> = emptyMap()
+  override val meta: Map<String, Any?> = emptyMap(),
+  override val sourceKey: String? = if (path == DotPath.root) null else path.flatten(),
 ) : PrimitiveNode() {
   override val simpleName: String = "null"
   override val value: Any? = null
@@ -204,6 +217,7 @@ object Undefined : Node {
   override val simpleName: String = "Undefined"
   override val pos: Pos = Pos.NoPos
   override val path = DotPath.root
+  override val sourceKey: String? = null
   override fun atKey(key: String): Node = this
   override fun atIndex(index: Int): Node = this
   override val size: Int = 0

--- a/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/nodes.kt
+++ b/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/nodes.kt
@@ -107,6 +107,18 @@ fun Node.paths(): Set<Pair<DotPath, Pos>> = setOf(this.path to this.pos) + when 
   else -> emptySet()
 }
 
+/**
+ * Return all nodes in this tree, recursively transformed per the given transformer function.
+ */
+fun Node.transform(transformer: (Node) -> Node): Node = when (val transformed = transformer(this)) {
+  is ArrayNode -> transformed.copy(elements = transformed.elements.map { it.transform(transformer) })
+  is MapNode -> transformed.copy(
+    map = transformed.map.mapValues { it.value.transform(transformer) },
+    value = transformed.value.transform(transformer)
+  )
+  else -> transformed
+}
+
 sealed class ContainerNode : Node
 
 data class MapNode(

--- a/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/parsers/loadProps.kt
+++ b/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/parsers/loadProps.kt
@@ -9,75 +9,95 @@ import com.sksamuel.hoplite.Undefined
 import com.sksamuel.hoplite.decoder.DotPath
 import java.util.Properties
 
-fun Properties.toNode(source: String, delimiter: String = ".") = asIterable().toNode(
+fun Properties.toNode(
+  source: String,
+  delimiter: String = ".",
+  keyExtractor: (Any) -> String = { it.toString() },
+) = asIterable().toNode(
   source = source,
-  keyExtractor = { it.key.toString() },
+  sourceKeyExtractor = { it.key },
+  keyExtractor = keyExtractor,
   valueExtractor = { it.value },
   delimiter = delimiter
 )
 
-fun <T : Any> Map<String, T?>.toNode(source: String, delimiter: String = ".") = entries.toNode(
+fun <T : Any> Map<String, T?>.toNode(
+  source: String,
+  delimiter: String = ".",
+  keyExtractor: (String) -> String = { it },
+) = entries.toNode(
   source = source,
-  keyExtractor = { it.key },
+  sourceKeyExtractor = { it.key },
+  keyExtractor = keyExtractor,
   valueExtractor = { it.value },
   delimiter = delimiter
 )
 
 data class Element(
   val values: MutableMap<String, Element> = hashMapOf(),
-  var value: Any? = null
+  var value: Any? = null,
+  var sourceKey: String? = null,
 )
 
-private fun <T> Iterable<T>.toNode(
+private fun <T, K> Iterable<T>.toNode(
   source: String,
-  keyExtractor: (T) -> String,
+  sourceKeyExtractor: (T) -> K,
+  keyExtractor: (K) -> String,
   valueExtractor: (T) -> Any?,
   delimiter: String = "."
 ): Node {
   val map = Element()
 
   forEach { item ->
-    val key = keyExtractor(item)
+    val sourceKey = sourceKeyExtractor(item)
+    val key = keyExtractor(sourceKey)
     val value = valueExtractor(item)
     val segments = key.split(delimiter)
 
     segments.foldIndexed(map) { index, element, segment ->
       element.values.getOrPut(segment) { Element() }.also {
-        if (index == segments.size - 1) it.value = value
+        if (index == segments.size - 1) {
+          it.value = value
+          it.sourceKey = sourceKey.toString()
+        }
       }
     }
   }
 
   val pos = Pos.SourcePos(source)
 
-  fun Any.transform(path: DotPath): Node = when (this) {
+  fun Any.transform(path: DotPath, parentSourceKey: String? = null): Node = when (this) {
     is Element -> when {
-      value != null && values.isEmpty() -> value?.transform(path) ?: Undefined
+      value != null && values.isEmpty() -> value?.transform(path, sourceKey) ?: Undefined
       else -> MapNode(
-        map = values.takeUnless { it.isEmpty() }?.mapValues { it.value.transform(path.with(it.key)) }.orEmpty(),
+        map = values.takeUnless { it.isEmpty() }?.mapValues { it.value.transform(path.with(it.key), sourceKey) }.orEmpty(),
         pos = pos,
         path = path,
-        value = value?.transform(path) ?: Undefined
+        value = value?.transform(path, sourceKey) ?: Undefined,
+        sourceKey = this.sourceKey,
       )
     }
     is Array<*> -> ArrayNode(
-      elements = mapNotNull { it?.transform(path) },
+      elements = mapNotNull { it?.transform(path, parentSourceKey) },
       pos = pos,
-      path = path
+      path = path,
+      sourceKey = parentSourceKey,
     )
     is Collection<*> -> ArrayNode(
-      elements = mapNotNull { it?.transform(path) },
+      elements = mapNotNull { it?.transform(path, parentSourceKey) },
       pos = pos,
-      path = path
+      path = path,
+      sourceKey = parentSourceKey,
     )
     is Map<*, *> -> MapNode(
       map = takeUnless { it.isEmpty() }?.mapNotNull { entry ->
-        entry.value?.let { entry.key.toString() to it.transform(path.with(entry.key.toString())) }
+        entry.value?.let { entry.key.toString() to it.transform(path.with(entry.key.toString()), parentSourceKey) }
       }?.toMap().orEmpty(),
       pos = pos,
-      path = path
+      path = path,
+      sourceKey = parentSourceKey,
     )
-    else -> StringNode(this.toString(), pos, path = path, emptyMap())
+    else -> StringNode(this.toString(), pos, path = path, emptyMap(), parentSourceKey)
   }
 
   return map.transform(DotPath.root)

--- a/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/preprocessor/LookupPreprocessor.kt
+++ b/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/preprocessor/LookupPreprocessor.kt
@@ -49,9 +49,9 @@ object LookupPreprocessor : Preprocessor {
     fun handle(n: Node): Node = when (n) {
       is MapNode -> {
         val value = if (n.value is StringNode) replace(replace(n.value, regex1), regex2) else n.value
-        MapNode(n.map.map { (k, v) -> k to handle(v) }.toMap(), n.pos, n.path, value)
+        MapNode(n.map.map { (k, v) -> k to handle(v) }.toMap(), n.pos, n.path, value, sourceKey = n.sourceKey)
       }
-      is ArrayNode -> ArrayNode(n.elements.map { handle(it) }, n.pos, n.path)
+      is ArrayNode -> ArrayNode(n.elements.map { handle(it) }, n.pos, n.path, sourceKey = n.sourceKey)
       is StringNode -> replace(replace(n, regex1), regex2)
       else -> n
     }

--- a/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/preprocessor/Preprocessor.kt
+++ b/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/preprocessor/Preprocessor.kt
@@ -44,14 +44,14 @@ abstract class TraversingPrimitivePreprocessor : Preprocessor {
         .map { it.toMap() }.flatMap { map ->
           val value = if (node.value is PrimitiveNode) handle(node.value, context) else node.value.valid()
           value.map { v ->
-            MapNode(map, node.pos, node.path, v)
+            MapNode(map, node.pos, node.path, v, sourceKey = node.sourceKey)
           }
         }
     }
     is ArrayNode -> {
       node.elements.map { process(it, context) }.sequence()
         .mapInvalid { ConfigFailure.MultipleFailures(it) }
-        .map { ArrayNode(it, node.pos, node.path) }
+        .map { ArrayNode(it, node.pos, node.path, sourceKey = node.sourceKey) }
     }
     is PrimitiveNode -> handle(node, context)
     else -> node.valid()

--- a/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/report/Reporter.kt
+++ b/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/report/Reporter.kt
@@ -44,6 +44,7 @@ class Reporter(
   object Titles {
     const val Key = "Key"
     const val Source = "Source"
+    const val SourceKey = "Source Key"
     const val Value = "Value"
   }
 
@@ -107,19 +108,22 @@ class Reporter(
           value = value ?: "<null>",
           pos = state.node.pos,
           path = state.node.path,
-          meta = state.node.meta
+          meta = state.node.meta,
+          sourceKey = state.node.sourceKey,
         )
       )
     }
 
     val keyPadded = max(Titles.Key.length, nodes.maxOf { it.node.path.flatten().length })
     val sourcePadded = nodes.maxOf { max(it.node.pos.source()?.length ?: 0, Titles.Source.length) }
+    val sourceKeyPadded = max(Titles.SourceKey.length, nodes.maxOf { it.node.sourceKey.orEmpty().length })
     val valuePadded = max(Titles.Value.length, obfuscated.maxOf { (it.node as StringNode).value.length })
 
     val rows = obfuscated.map {
       listOfNotNull(
         it.node.path.flatten().padEnd(keyPadded, ' '),
         (it.node.pos.source() ?: "").padEnd(sourcePadded, ' '),
+        it.node.sourceKey.orEmpty().padEnd(sourceKeyPadded, ' '),
         (it.node as StringNode).value.padEnd(valuePadded, ' ')
       ).joinToString(" | ", "| ", " |")
     }
@@ -129,12 +133,14 @@ class Reporter(
     val bar = listOfNotNull(
       "".padEnd(keyPadded + 2, '-'),
       "".padEnd(sourcePadded + 2, '-'),
+      "".padEnd(sourceKeyPadded + 2, '-'),
       "".padEnd(valuePadded + 2, '-')
     ).joinToString("+", "+", "+")
 
     val titles = listOfNotNull(
       Titles.Key.padEnd(keyPadded, ' '),
       Titles.Source.padEnd(sourcePadded, ' '),
+      Titles.SourceKey.padEnd(sourceKeyPadded, ' '),
       Titles.Value.padEnd(valuePadded, ' ')
     ).joinToString(" | ", "| ", " |")
 

--- a/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/sources/EnvironmentVariableOverridePropertySource.kt
+++ b/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/sources/EnvironmentVariableOverridePropertySource.kt
@@ -25,13 +25,13 @@ class EnvironmentVariableOverridePropertySource(
   override fun source(): String = "Env Var Overrides"
 
   override fun node(context: PropertySourceContext): ConfigResult<Node> {
-    val props = Properties()
     val vars = environmentVariableMap()
       .mapKeys { if (useUnderscoresAsSeparator) it.key.replace("__", ".") else it.key }
       .filter { it.key.startsWith(Prefix) }
     return if (vars.isEmpty()) Undefined.valid() else {
-      vars.forEach { props[it.key.removePrefix(Prefix)] = it.value }
-      props.toNode("Env Var Overrides").valid()
+      vars.toNode("Env Var Overrides") {
+        it.removePrefix(Prefix)
+      }.valid()
     }
   }
 }

--- a/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/sources/SystemPropertiesPropertySource.kt
+++ b/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/sources/SystemPropertiesPropertySource.kt
@@ -23,13 +23,10 @@ open class SystemPropertiesPropertySource(
   override fun source(): String = "System Properties"
 
   override fun node(context: PropertySourceContext): ConfigResult<Node> {
-    val props = Properties()
-    systemPropertiesMap().let { systemPropertiesMap ->
-      systemPropertiesMap.keys
-        .filter { it.startsWith(prefix) }
-        .forEach { props[it.removePrefix(prefix)] = systemPropertiesMap[it] }
-    }
-    return if (props.isEmpty) Undefined.valid() else props.toNode("sysprops").valid()
+    val map = systemPropertiesMap().filter { it.key.startsWith(prefix) }
+    return if (map.isEmpty()) Undefined.valid() else map.toNode("sysprops") {
+      it.removePrefix(prefix)
+    }.valid()
   }
 
   companion object : SystemPropertiesPropertySource() {

--- a/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/transformer/NodeTransformer.kt
+++ b/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/transformer/NodeTransformer.kt
@@ -1,0 +1,11 @@
+package com.sksamuel.hoplite.transformer
+
+import com.sksamuel.hoplite.*
+
+/**
+ * A [NodeTransformer] is a function that transforms a node into another node. Any type of node transformation can
+ * be applied at configuration loading time.
+ */
+interface NodeTransformer {
+  fun transform(node: Node): Node
+}

--- a/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/transformer/NodeTransformer.kt
+++ b/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/transformer/NodeTransformer.kt
@@ -7,5 +7,5 @@ import com.sksamuel.hoplite.*
  * be applied at configuration loading time.
  */
 interface NodeTransformer {
-  fun transform(node: Node): Node
+  fun transform(node: Node, sealedTypeDiscriminatorField: String?): Node
 }

--- a/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/transformer/PathNormalizer.kt
+++ b/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/transformer/PathNormalizer.kt
@@ -1,0 +1,35 @@
+package com.sksamuel.hoplite.transformer
+
+import com.sksamuel.hoplite.*
+
+/**
+ * To support loading configuration from a tree based on multiple sources with different idiomatic conventions, such
+ * as HOCON which prefers kebab case, and environment variables which are upper-case, the path normalizer normalizes
+ * all paths so that the cascade happens correctly. For example, a `foo.conf` containing the HOCON standard naming
+ * of `abc.foo-bar` and an env var `ABC_FOOBAR` would both get mapped to data class `Foo { val fooBar: String }`
+ * assuming there is a Lowercase parameter mapper present.
+ *
+ * Note that with path normalization, parameters with the same name but different case will be considered the same,
+ * and assigned the same value. This should generally be a situation one should avoid, but if it does happen, please
+ * consider the use of the @[ConfigAlias] annotation to disambiguate the properties.
+ *
+ * Path normalization does the following for all node keys and each element of each node's path:
+ * * Removes dashes
+ * * Converts to lower-case
+ */
+object PathNormalizer : NodeTransformer {
+  fun normalizePathElement(element: String): String = element.replace("-", "").lowercase()
+
+  override fun transform(node: Node): Node = node
+    .transform {
+      val normalizedPathNode = it.withPath(
+        it.path.copy(keys = it.path.keys.map { key ->
+          normalizePathElement(key)
+        })
+      )
+      when (normalizedPathNode){
+        is MapNode -> normalizedPathNode.copy(map = normalizedPathNode.map.mapKeys { (key, _) -> normalizePathElement(key) })
+        else -> normalizedPathNode
+      }
+    }
+}

--- a/hoplite-core/src/test/kotlin/com/sksamuel/hoplite/CascadingNormalizationTest.kt
+++ b/hoplite-core/src/test/kotlin/com/sksamuel/hoplite/CascadingNormalizationTest.kt
@@ -1,0 +1,36 @@
+package com.sksamuel.hoplite
+
+import com.sksamuel.hoplite.sources.EnvironmentVariablesPropertySource
+import com.sksamuel.hoplite.sources.MapPropertySource
+import com.sksamuel.hoplite.transformer.PathNormalizer
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+@OptIn(ExperimentalHoplite::class)
+class CascadingNormalizationTest : FunSpec() {
+  init {
+    test("Parameter normalization works with cascading") {
+      data class SubSection(val someValue: Int)
+      data class Section(val test: Int, val subSection: SubSection)
+      data class TestConfig(val section: Section)
+
+      val configInputs = mapOf("section" to mapOf("test" to 1, "sub-section" to mapOf("some-value" to 2)))
+
+      val config = ConfigLoaderBuilder.newBuilder()
+        .addNodeTransformer(PathNormalizer)
+        .addPropertySource(
+          EnvironmentVariablesPropertySource(
+            useUnderscoresAsSeparator = false,
+            allowUppercaseNames = false,
+            environmentVariableMap = { mapOf("section.subSection.someValue" to "3") }
+          )
+        )
+        .addPropertySource(MapPropertySource(configInputs))
+        .build()
+        .loadConfigOrThrow<TestConfig>()
+
+      config.section.subSection.someValue shouldBe 3
+    }
+  }
+
+}

--- a/hoplite-core/src/test/kotlin/com/sksamuel/hoplite/EmptyDecoderRegistryTest.kt
+++ b/hoplite-core/src/test/kotlin/com/sksamuel/hoplite/EmptyDecoderRegistryTest.kt
@@ -14,12 +14,14 @@ class EmptyDecoderRegistryTest : FunSpec() {
       val parsers = defaultParserRegistry()
       val sources = defaultPropertySources()
       val preprocessors = defaultPreprocessors()
+      val nodeTransformers = defaultNodeTransformers()
       val mappers = defaultParamMappers()
       val e = ConfigLoader(
         DecoderRegistry.zero,
         sources,
         parsers,
         preprocessors,
+        nodeTransformers,
         mappers,
         allowEmptyTree = false,
         allowUnresolvedSubstitutions = false,

--- a/hoplite-core/src/test/kotlin/com/sksamuel/hoplite/EnvironmentVariablesPropertySourceTest.kt
+++ b/hoplite-core/src/test/kotlin/com/sksamuel/hoplite/EnvironmentVariablesPropertySourceTest.kt
@@ -17,12 +17,13 @@ class EnvironmentVariablesPropertySourceTest : FunSpec({
     ).getUnsafe() shouldBe MapNode(
       mapOf(
         "a" to MapNode(
-          value = StringNode("foo", Pos.env, DotPath("a")),
-          map = mapOf("b" to StringNode("bar", Pos.env, DotPath("a", "b"))),
+          value = StringNode("foo", Pos.env, DotPath("a"), sourceKey = "a"),
+          map = mapOf("b" to StringNode("bar", Pos.env, DotPath("a", "b"), sourceKey = "a.b")),
           pos = Pos.SourcePos("env"),
-          path = DotPath("a")
+          path = DotPath("a"),
+          sourceKey = "a"
         ),
-        "c" to StringNode("baz", Pos.env, DotPath("c"))
+        "c" to StringNode("baz", Pos.env, DotPath("c"), sourceKey = "c"),
       ),
       pos = Pos.env,
       DotPath.root

--- a/hoplite-core/src/test/kotlin/com/sksamuel/hoplite/LoadPropsTest.kt
+++ b/hoplite-core/src/test/kotlin/com/sksamuel/hoplite/LoadPropsTest.kt
@@ -21,33 +21,37 @@ class LoadPropsTest : FunSpec({
           mapOf(
             "b" to MapNode(
               mapOf(
-                "c" to StringNode("wibble", pos = Pos.SourcePos(source = "source"), DotPath("a", "b", "c")),
-                "d" to StringNode("123", pos = Pos.SourcePos(source = "source"), DotPath("a", "b", "d"))
+                "c" to StringNode("wibble", pos = Pos.SourcePos(source = "source"), DotPath("a", "b", "c"), sourceKey = "a.b.c"),
+                "d" to StringNode("123", pos = Pos.SourcePos(source = "source"), DotPath("a", "b", "d"), sourceKey = "a.b.d")
               ),
               pos = Pos.SourcePos(source = "source"),
               DotPath("a", "b"),
-              value = Undefined
+              value = Undefined,
+              sourceKey = null
             ),
-            "d" to StringNode("true", pos = Pos.SourcePos(source = "source"), DotPath("a", "d"))
+            "d" to StringNode("true", pos = Pos.SourcePos(source = "source"), DotPath("a", "d"), sourceKey = "a.d")
           ),
           pos = Pos.SourcePos(source = "source"),
           DotPath("a"),
-          value = StringNode("foo", Pos.SourcePos(source = "source"), DotPath("a"))
+          value = StringNode("foo", Pos.SourcePos(source = "source"), DotPath("a"), sourceKey = "a"),
+          sourceKey = "a"
         ),
         "e" to MapNode(
           mapOf(
             "f" to MapNode(
               mapOf(
-                "g" to StringNode("goo", pos = Pos.SourcePos(source = "source"), DotPath("e", "f", "g"))
+                "g" to StringNode("goo", pos = Pos.SourcePos(source = "source"), DotPath("e", "f", "g"), sourceKey = "e.f.g")
               ),
               pos = Pos.SourcePos(source = "source"),
               DotPath("e", "f"),
-              value = StringNode("6", Pos.SourcePos(source = "source"), DotPath("e", "f"))
+              value = StringNode("6", Pos.SourcePos(source = "source"), DotPath("e", "f"), sourceKey = "e.f"),
+              sourceKey = "e.f"
             )
           ),
           pos = Pos.SourcePos(source = "source"),
           DotPath("e"),
-          value = StringNode("5.5", Pos.SourcePos(source = "source"), DotPath("e"))
+          value = StringNode("5.5", Pos.SourcePos(source = "source"), DotPath("e"), sourceKey = "e"),
+          sourceKey = "e"
         )
       ),
       pos = Pos.SourcePos(source = "source"),

--- a/hoplite-core/src/test/kotlin/com/sksamuel/hoplite/PropsParserTest.kt
+++ b/hoplite-core/src/test/kotlin/com/sksamuel/hoplite/PropsParserTest.kt
@@ -18,20 +18,23 @@ class PropsParserTest : StringSpec() {
                     "c" to StringNode(
                       value = "wibble",
                       pos = Pos.SourcePos(source = "a.props"),
-                      DotPath("a", "b", "c")
+                      DotPath("a", "b", "c"),
+                      sourceKey = "a.b.c"
                     ),
-                    "d" to StringNode(value = "123", pos = Pos.SourcePos(source = "a.props"), DotPath("a", "b", "d"))
+                    "d" to StringNode(value = "123", pos = Pos.SourcePos(source = "a.props"), DotPath("a", "b", "d"), sourceKey = "a.b.d")
                   ),
                   pos = Pos.SourcePos(source = "a.props"),
                   DotPath("a", "b"),
-                  value = StringNode("qqq", pos = Pos.SourcePos(source = "a.props"), DotPath("a", "b"))
+                  value = StringNode("qqq", pos = Pos.SourcePos(source = "a.props"), DotPath("a", "b"), sourceKey = "a.b"),
+                  sourceKey = "a.b"
                 ),
-                "g" to StringNode(value = "true", pos = Pos.SourcePos(source = "a.props"), DotPath("a", "g"))
+                "g" to StringNode(value = "true", pos = Pos.SourcePos(source = "a.props"), DotPath("a", "g"), sourceKey = "a.g")
               ),
               pos = Pos.SourcePos(source = "a.props"),
-              DotPath("a")
+              DotPath("a"),
+              sourceKey = null
             ),
-            "e" to StringNode(value = "5.5", pos = Pos.SourcePos(source = "a.props"), DotPath("e"))
+            "e" to StringNode(value = "5.5", pos = Pos.SourcePos(source = "a.props"), DotPath("e"), sourceKey = "e")
           ),
           pos = Pos.SourcePos(source = "a.props"),
           DotPath.root

--- a/hoplite-core/src/test/kotlin/com/sksamuel/hoplite/ReporterTest.kt
+++ b/hoplite-core/src/test/kotlin/com/sksamuel/hoplite/ReporterTest.kt
@@ -40,14 +40,14 @@ class ReporterTest : FunSpec({
     }.shouldContain(
       """
 Used keys: 4
-+----------+---------------------+----------+
-| Key      | Source              | Value    |
-+----------+---------------------+----------+
-| host     | props string source | loc***** |
-| name     | props string source | my ***** |
-| password | props string source | ssm***** |
-| port     | props string source | 3306     |
-+----------+---------------------+----------+
++----------+---------------------+------------+----------+
+| Key      | Source              | Source Key | Value    |
++----------+---------------------+------------+----------+
+| host     | props string source | host       | loc***** |
+| name     | props string source | name       | my ***** |
+| password | props string source | password   | ssm***** |
+| port     | props string source | port       | 3306     |
++----------+---------------------+------------+----------+
 """
     )
 
@@ -98,14 +98,14 @@ Property sources (highest to lowest priority):
     }.shouldContain(
       """
 Used keys: 4
-+----------+---------------------+----------+
-| Key      | Source              | Value    |
-+----------+---------------------+----------+
-| host     | props string source | lr*****  |
-| name     | props string source | my ***** |
-| password | props string source | ssm***** |
-| port     | props string source | 3306     |
-+----------+---------------------+----------+
++----------+---------------------+------------+----------+
+| Key      | Source              | Source Key | Value    |
++----------+---------------------+------------+----------+
+| host     | props string source | host       | lr*****  |
+| name     | props string source | name       | my ***** |
+| password | props string source | password   | ssm***** |
+| port     | props string source | port       | 3306     |
++----------+---------------------+------------+----------+
 """
     )
 
@@ -131,12 +131,12 @@ Used keys: 4
     }
 
     out shouldContain """
-+---------------+---------------------+----------+
-| Key           | Source              | Value    |
-+---------------+---------------------+----------+
-| database.name | props string source | my ***** |
-| database.port | props string source | 3306     |
-+---------------+---------------------+----------+
++---------------+---------------------+---------------+----------+
+| Key           | Source              | Source Key    | Value    |
++---------------+---------------------+---------------+----------+
+| database.name | props string source | database.name | my ***** |
+| database.port | props string source | database.port | 3306     |
++---------------+---------------------+---------------+----------+
 """.trim()
 
   }
@@ -177,14 +177,14 @@ Used keys: 4
     }.shouldContain(
       """
 Used keys: 4
-+----------+---------------------+-------------+
-| Key      | Source              | Value       |
-+----------+---------------------+-------------+
-| host     | props string source | localhost   |
-| name     | props string source | my database |
-| password | props string source | gcp*****    |
-| port     | props string source | 3306        |
-+----------+---------------------+-------------+
++----------+---------------------+------------+-------------+
+| Key      | Source              | Source Key | Value       |
++----------+---------------------+------------+-------------+
+| host     | props string source | host       | localhost   |
+| name     | props string source | name       | my database |
+| password | props string source | password   | gcp*****    |
+| port     | props string source | port       | 3306        |
++----------+---------------------+------------+-------------+
 
 """
     )

--- a/hoplite-core/src/test/kotlin/com/sksamuel/hoplite/WithoutDefaultsRegistryTest.kt
+++ b/hoplite-core/src/test/kotlin/com/sksamuel/hoplite/WithoutDefaultsRegistryTest.kt
@@ -5,6 +5,7 @@ import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.types.instanceOf
+import io.kotest.matchers.types.shouldBeInstanceOf
 
 class WithoutDefaultsRegistryTest : FunSpec() {
   init {
@@ -13,7 +14,7 @@ class WithoutDefaultsRegistryTest : FunSpec() {
         addMapSource(mapOf("custom_value" to "\${PATH}", "PATH" to "\${PATH}"))
       }
       val e = loader.loadConfig<Config>()
-      e as Validated.Valid<Config>
+      e.shouldBeInstanceOf<Validated.Valid<Config>>()
       e.value.customValue shouldNotBe "\${path}"
     }
 

--- a/hoplite-core/src/test/kotlin/com/sksamuel/hoplite/transformer/PathNormalizerTest.kt
+++ b/hoplite-core/src/test/kotlin/com/sksamuel/hoplite/transformer/PathNormalizerTest.kt
@@ -17,7 +17,7 @@ class PathNormalizerTest : FunSpec({
       environmentVariableMap = { mapOf("A" to "a", "A.B" to "ab", "A.B.CD" to "abcd") },
     ).node(PropertySourceContext.empty).getUnsafe()
 
-    PathNormalizer.transform(node) shouldBe MapNode(
+    PathNormalizer.transform(node, null) shouldBe MapNode(
       map = mapOf(
         "a" to MapNode(
           map = mapOf(

--- a/hoplite-core/src/test/kotlin/com/sksamuel/hoplite/transformer/PathNormalizerTest.kt
+++ b/hoplite-core/src/test/kotlin/com/sksamuel/hoplite/transformer/PathNormalizerTest.kt
@@ -1,0 +1,44 @@
+package com.sksamuel.hoplite.transformer
+
+import com.sksamuel.hoplite.MapNode
+import com.sksamuel.hoplite.Pos
+import com.sksamuel.hoplite.PropertySourceContext
+import com.sksamuel.hoplite.StringNode
+import com.sksamuel.hoplite.decoder.DotPath
+import com.sksamuel.hoplite.sources.EnvironmentVariablesPropertySource
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+class PathNormalizerTest : FunSpec({
+  test("normalizes paths") {
+    val node = EnvironmentVariablesPropertySource(
+      useUnderscoresAsSeparator = false,
+      allowUppercaseNames = false,
+      environmentVariableMap = { mapOf("A" to "a", "A.B" to "ab", "A.B.CD" to "abcd") },
+    ).node(PropertySourceContext.empty).getUnsafe()
+
+    PathNormalizer.transform(node) shouldBe MapNode(
+      map = mapOf(
+        "a" to MapNode(
+          map = mapOf(
+            "b" to MapNode(
+              map = mapOf(
+                "cd" to StringNode("abcd", Pos.env, DotPath("a", "b", "cd"), sourceKey = "A.B.CD"),
+              ),
+              Pos.env,
+              DotPath("a", "b"),
+              value = StringNode("ab", Pos.env, DotPath("a", "b"), sourceKey = "A.B"),
+              sourceKey = "A.B"
+            ),
+          ),
+          Pos.env,
+          DotPath("a"),
+          value = StringNode("a", Pos.env, DotPath("a"), sourceKey = "A"),
+          sourceKey = "A"
+        ),
+      ),
+      Pos.env,
+      DotPath.root,
+    )
+  }
+})

--- a/hoplite-hikaricp/src/main/kotlin/com/sksamuel/hoplite/hikari/HikariDataSourceDecoder.kt
+++ b/hoplite-hikaricp/src/main/kotlin/com/sksamuel/hoplite/hikari/HikariDataSourceDecoder.kt
@@ -6,7 +6,7 @@ import com.sksamuel.hoplite.DecoderContext
 import com.sksamuel.hoplite.MapNode
 import com.sksamuel.hoplite.Node
 import com.sksamuel.hoplite.PrimitiveNode
-import com.sksamuel.hoplite.decoder.Decoder
+import com.sksamuel.hoplite.decoder.AbstractUnnormalizedKeysDecoder
 import com.sksamuel.hoplite.fp.invalid
 import com.sksamuel.hoplite.fp.valid
 import com.zaxxer.hikari.HikariConfig
@@ -14,11 +14,11 @@ import com.zaxxer.hikari.HikariDataSource
 import java.util.Properties
 import kotlin.reflect.KType
 
-class HikariDataSourceDecoder : Decoder<HikariDataSource> {
+class HikariDataSourceDecoder : AbstractUnnormalizedKeysDecoder<HikariDataSource>() {
 
   override fun supports(type: KType): Boolean = type.classifier == HikariDataSource::class
 
-  override fun decode(node: Node, type: KType, context: DecoderContext): ConfigResult<HikariDataSource> {
+  override fun safeDecodeUnnormalized(node: Node, type: KType, context: DecoderContext): ConfigResult<HikariDataSource> {
 
     val props = Properties()
 

--- a/hoplite-hikaricp/src/test/kotlin/com/sksamuel/hoplite/HikariDataSourceTest.kt
+++ b/hoplite-hikaricp/src/test/kotlin/com/sksamuel/hoplite/HikariDataSourceTest.kt
@@ -1,7 +1,8 @@
 package com.sksamuel.hoplite
 
 import com.zaxxer.hikari.HikariDataSource
-import io.kotest.assertions.throwables.shouldThrowAny
+import com.zaxxer.hikari.pool.HikariPool
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.string.shouldContain
 
@@ -10,7 +11,7 @@ class HikariDataSourceTest : StringSpec() {
     "hikari datasource decoder" {
       data class Config(val db: HikariDataSource)
 
-      shouldThrowAny {
+      shouldThrow<HikariPool.PoolInitializationException> {
         ConfigLoader().loadConfigOrThrow<Config>("/hikari.yaml").db
       }.cause?.cause?.message shouldContain "serverhost"
     }


### PR DESCRIPTION
Add a generic node transformer interface `NodeTransformer`, which can be used to transform nodes in arbitrary ways at configuration load time.

Add an implementation of this called `PathNormalizer`.

The purpose of the path normalizer is to normalize all inbound paths by making them lower case, and removing any "-" and "_" characters. Normalizing paths means sources with different idiomatic approaches to defining key values will all map correctly to the defined config classes. It makes it possible to implement https://github.com/sksamuel/hoplite/issues/410.

The only downside to this is multiple config attributes in the same class that differ only by case can no longer be disambiguated. This should be a rare case and the advantages are more than worth losing this "feature". ~~Therefore, in my opinion this should be installed by default, but I have not done that in this PR until I hear some feedback from @sksamuel.~~ The feature is thus installed by default, and the now unnecessary parameter mappers removed by default.

We also add a `LowercaseParameterMapper` by default which can handle the normalized paths.

~~This PR is stacked on top of https://github.com/sksamuel/hoplite/pull/412 and will be rebased and moved out of draft once that PR is merged.~~