### PR TITLE
Allow two-step parsing and decoding/binding

### DIFF
--- a/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/ConfigBinder.kt
+++ b/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/ConfigBinder.kt
@@ -1,0 +1,36 @@
+package com.sksamuel.hoplite
+
+import com.sksamuel.hoplite.env.Environment
+import com.sksamuel.hoplite.internal.ConfigParser
+import kotlin.reflect.KClass
+
+/**
+ * Maintains a parsed configuration which can be used to bind to multiple configuration classes with a prefix.
+ */
+class ConfigBinder(
+  @PublishedApi internal val configParser: ConfigParser,
+  @PublishedApi internal val environment: Environment?,
+  private val onFailure: List<(Throwable) -> Unit> = emptyList(),
+) {
+  /**
+   * Binds the configuration to a configuration class, looking at  with the given prefix.
+   */
+  inline fun <reified A : Any> bind(prefix: String): ConfigResult<A> = bind(A::class, prefix)
+
+  /**
+   * Binds the configuration to a configuration class, looking at  with the given prefix.
+   */
+  inline fun <reified A : Any> bindOrThrow(prefix: String): A = bindOrThrow(A::class, prefix)
+
+  /**
+   * Binds the configuration to a configuration class with the given prefix.
+   */
+  fun <A : Any> bind(type: KClass<A>, prefix: String): ConfigResult<A> =
+    configParser.decode(type, environment, prefix)
+
+  /**
+   * Binds the configuration to a configuration class with the given prefix, or throws if the result is not valid.
+   */
+  fun <A : Any> bindOrThrow(type: KClass<A>, prefix: String): A =
+    configParser.decode(type, environment, prefix).returnOrThrow(onFailure)
+}

--- a/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/internal/ConfigParser.kt
+++ b/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/internal/ConfigParser.kt
@@ -36,7 +36,6 @@ class ConfigParser(
   preprocessors: List<Preprocessor>,
   preprocessingIterations: Int,
   private val nodeTransformers: List<NodeTransformer>,
-  private val prefix: String?,
   private val resolvers: List<Resolver>,
   private val decoderRegistry: DecoderRegistry,
   private val paramMappers: List<ParameterMapper>,
@@ -51,12 +50,21 @@ class ConfigParser(
   private val environment: Environment?,
   private val sealedTypeDiscriminatorField: String?,
   private val contextResolverMode: ContextResolverMode,
+  private val resourceOrFiles: List<String>,
+  private val propertySources: List<PropertySource>,
+  private val configSources: List<ConfigSource>,
 ) {
 
   private val loader = PropertySourceLoader(nodeTransformers, sealedTypeDiscriminatorField, classpathResourceLoader, parserRegistry, allowEmptyTree)
   private val cascader = Cascader(cascadeMode, allowEmptyTree, allowNullOverride)
   private val preprocessing = Preprocessing(preprocessors, preprocessingIterations)
   private val decoding = Decoding(decoderRegistry, secretsPolicy)
+  private lateinit var configResult: ConfigResult<Node>
+  private lateinit var context: DecoderContext
+
+  init {
+    loadResultAndContext()
+  }
 
   private fun context(root: Node): DecoderContext {
     return DecoderContext(
@@ -73,47 +81,51 @@ class ConfigParser(
   fun <A : Any> decode(
     kclass: KClass<A>,
     environment: Environment?,
-    resourceOrFiles: List<String>,
-    propertySources: List<PropertySource>,
-    configSources: List<ConfigSource>,
+    prefix: String? = null,
   ): ConfigResult<A> {
 
-    if (decoderRegistry.size == 0)
-      return ConfigFailure.EmptyDecoderRegistry.invalid()
-
-    return loader.loadNodes(propertySources, configSources, resourceOrFiles).flatMap { nodes ->
-      cascader.cascade(nodes).flatMap { node ->
-        val context = context(node)
-        preprocessing.preprocess(node, context).flatMap { preprocessed ->
-          check(preprocessed.prefixedNode()).flatMap {
-            val decoded = decoding.decode(kclass, it, decodeMode, context)
-            val state = createDecodingState(it, context, secretsPolicy)
-
-            // always do report regardless of decoder result
-            if (useReport) {
-              Reporter(reportPrintFn, obfuscator, environment)
-                .printReport(propertySources, state, context.reporter.getReport())
-            }
-
-            decoded
-          }
-        }
-      }
+    if (configResult.isInvalid()) {
+      return configResult.getInvalidUnsafe().invalid()
     }
+
+    return configResult
+      .map { it.prefixedNode(prefix) }
+      .flatMap {
+        val decoded = decoding.decode(kclass, it, decodeMode, context)
+        val state = createDecodingState(it, context, secretsPolicy)
+
+        // always do report regardless of decoder result
+        if (useReport) {
+          Reporter(reportPrintFn, obfuscator, environment, prefix)
+            .printReport(propertySources, state, context.reporter.getReport())
+        }
+
+        decoded
+      }
   }
 
-  fun load(
-    resourceOrFiles: List<String>,
-    propertySources: List<PropertySource>,
-    configSources: List<ConfigSource>,
-  ): ConfigResult<Node> {
-    return loader.loadNodes(propertySources, configSources, resourceOrFiles).flatMap { nodes ->
+  fun load(): ConfigResult<Node> = configResult
+
+  private fun loadResultAndContext() {
+    if (decoderRegistry.size == 0) {
+      configResult = ConfigFailure.EmptyDecoderRegistry.invalid()
+      return
+    }
+
+    loader.loadNodes(propertySources, configSources, resourceOrFiles).flatMap { nodes ->
       cascader.cascade(nodes).flatMap { node ->
         val context = context(node)
         preprocessing.preprocess(node, context).flatMap { preprocessed ->
-          if (allowUnresolvedSubstitutions) preprocessed.valid() else UnresolvedSubstitutionChecker.process(preprocessed)
+          check(preprocessed)
+        }.map {
+          it to context
         }
       }
+    }.onSuccess { result ->
+      configResult = result.first.valid()
+      context = result.second
+    }.onFailure { result ->
+      configResult = result.invalid()
     }
   }
 
@@ -125,7 +137,7 @@ class ConfigParser(
       UnresolvedSubstitutionChecker.process(node)
   }
 
-  private fun Node.prefixedNode() = when {
+  private fun Node.prefixedNode(prefix: String?) = when {
     prefix == null -> this
     nodeTransformers.contains(PathNormalizer) -> atPath(PathNormalizer.normalizePathElement(prefix))
     else -> atPath(prefix)

--- a/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/report/Reporter.kt
+++ b/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/report/Reporter.kt
@@ -30,7 +30,7 @@ class ReporterBuilder {
   @Deprecated("Specify secretsPolicy through ConfigBuilderLoader", level = DeprecationLevel.ERROR)
   fun withSecretsPolicy(secretsPolicy: SecretsPolicy): ReporterBuilder = TODO("Unsupported")
 
-  fun build(): Reporter = Reporter(print, obfuscator, null)
+  fun build(): Reporter = Reporter(print, obfuscator, null, null)
 }
 
 typealias Print = (String) -> Unit
@@ -38,7 +38,8 @@ typealias Print = (String) -> Unit
 class Reporter(
   private val print: Print,
   private val obfuscator: Obfuscator,
-  private val environment: Environment?
+  private val environment: Environment?,
+  private val prefix: String?
 ) {
 
   object Titles {
@@ -60,10 +61,12 @@ class Reporter(
 
     val r = buildString {
       appendLine()
-      appendLine("--Start Hoplite Config Report---")
+      appendLine("--Start Hoplite Config Report${if (prefix != null) " @ Prefix $prefix" else ""}---")
       appendLine()
-      environment?.let { appendLine("Environment: ${it.name}") }
-      appendLine()
+      environment?.let {
+        appendLine("Environment: ${it.name}")
+        appendLine()
+      }
       appendLine(report(sources))
       appendLine()
 


### PR DESCRIPTION
Modify `ConfigLoader` and `ConfigParser` so that the config is parsed only a single time. `ConfigLoader.configBinder()` can now be called to obtain the instance of a new class `ConfigBinder`, which can in turn be used to bind the already parsed config to multiple data classes, given a prefix.

This follows the general approach [as suggested by @cloudshiftchris](https://github.com/sksamuel/hoplite/issues/386#issuecomment-1778243878).