### PR TITLE
Cascader should carry through the source key from the override

### DIFF
--- a/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/internal/cascade.kt
+++ b/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/internal/cascade.kt
@@ -71,7 +71,7 @@ class Cascader(
               val overrides = merges.values.toList().flatMap { it.overrides }
               val elements = merges.mapValues { it.value.node }
               CascadeResult(
-                MapNode(elements, a.pos, a.path, cascade(a.value, b.value).node),
+                MapNode(elements, a.pos, a.path, cascade(a.value, b.value).node, a.meta, a.sourceKey),
                 overrides
               )
             }

--- a/hoplite-yaml/src/test/kotlin/com/sksamuel/hoplite/yaml/DenormalizedMapKeysTest.kt
+++ b/hoplite-yaml/src/test/kotlin/com/sksamuel/hoplite/yaml/DenormalizedMapKeysTest.kt
@@ -2,8 +2,10 @@ package com.sksamuel.hoplite.yaml
 
 import com.sksamuel.hoplite.ConfigLoaderBuilder
 import com.sksamuel.hoplite.addCommandLineSource
+import com.sksamuel.hoplite.addEnvironmentSource
 import com.sksamuel.hoplite.addResourceOrFileSource
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.extensions.system.withEnvironment
 import io.kotest.matchers.shouldBe
 
 class DenormalizedMapKeysTest : FunSpec({
@@ -48,5 +50,34 @@ class DenormalizedMapKeysTest : FunSpec({
         "DC2" to Foo("20"),
       )
     )
+  }
+
+  test("should set denormalized map keys from environment variables") {
+    withEnvironment(
+      mapOf(
+        "m.DC1.x-val" to "15",
+        "m.DC2.x-val" to "25"
+      )
+    ) {
+      val config = ConfigLoaderBuilder.default()
+        .addEnvironmentSource()
+        .addResourceOrFileSource("/test_data_class_in_map.yaml")
+        .build()
+        .loadConfigOrThrow<MapContainer>()
+
+      config shouldBe MapContainer(
+        m = mapOf(
+          "DC1" to Foo("15"),
+          "DC2" to Foo("25"),
+        )
+      )
+      /*
+       but actually, it is:
+       {
+        "dc2" = Foo(xVal=25),
+        "dc1" = Foo(xVal=15)
+       }
+       */
+    }
   }
 })

--- a/hoplite-yaml/src/test/kotlin/com/sksamuel/hoplite/yaml/DenormalizedMapKeysTest.kt
+++ b/hoplite-yaml/src/test/kotlin/com/sksamuel/hoplite/yaml/DenormalizedMapKeysTest.kt
@@ -144,4 +144,24 @@ class DenormalizedMapKeysTest : FunSpec({
       )
     }
   }
+
+  test("should set denormalized map keys from command line arguments with the CLI case") {
+    val config = ConfigLoaderBuilder.default()
+      .addCommandLineSource(
+        arrayOf(
+          "--m.Dc1.x-val=20",
+          "--m.Dc2.x-val=30",
+        ),
+      )
+      .addResourceOrFileSource("/test_data_class_in_map.yaml")
+      .build()
+      .loadConfigOrThrow<MapContainer>()
+
+    config shouldBe MapContainer(
+      m = mapOf(
+        "Dc1" to Foo("20"),
+        "Dc2" to Foo("30"),
+      )
+    )
+  }
 })


### PR DESCRIPTION
Resolves #447 .

The cascader should persist the source key from the override.

In addition, we copy the meta data as well, if any exists.

@osoykan Can you test this in your local env?