### PR TITLE
Migrate arrow to 2.0.1

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,8 +29,8 @@ allprojects {
    version = Ci.version
 
    dependencies {
-      testImplementation("io.kotest:kotest-assertions-core:5.5.5")
-      testImplementation("io.kotest:kotest-runner-junit5:5.5.5")
+      testImplementation("io.kotest:kotest-assertions-core:5.9.1")
+      testImplementation("io.kotest:kotest-runner-junit5:5.9.1")
    }
 
    tasks.named<Test>("test") {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -50,7 +50,7 @@ enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
 dependencyResolutionManagement {
    versionCatalogs {
       create("libs") {
-         val kotlin = "1.9.25"
+         val kotlin = "2.1.0"
          plugin("kotlin-jvm", "org.jetbrains.kotlin.jvm").version(kotlin)
          plugin("kotlin-serialization","org.jetbrains.kotlin.plugin.serialization").version(kotlin)
          library("kotlin-reflect", "org.jetbrains.kotlin:kotlin-reflect:$kotlin")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -67,7 +67,7 @@ dependencyResolutionManagement {
 
          library("typesafe-config", "com.typesafe:config:1.4.3")
 
-         library("arrow-core", "io.arrow-kt:arrow-core:1.1.3")
+         library("arrow-core", "io.arrow-kt:arrow-core:2.0.1")
 
          library("spring-vault-core", "org.springframework.vault:spring-vault-core:2.3.4")
 


### PR DESCRIPTION
In order to use Arrow 2.0.1, it is also needed to bump Kotlin and Kotest versions to use the K2 compiler.