### PR TITLE
feat: handle inline class constructor exceptions like data class

### DIFF
--- a/hoplite-core/src/test/kotlin/com/sksamuel/hoplite/decoder/InlineClassDecoderTest.kt
+++ b/hoplite-core/src/test/kotlin/com/sksamuel/hoplite/decoder/InlineClassDecoderTest.kt
@@ -1,0 +1,35 @@
+package com.sksamuel.hoplite.decoder
+
+import com.sksamuel.hoplite.ConfigFailure
+import com.sksamuel.hoplite.DecoderContext
+import com.sksamuel.hoplite.LongNode
+import com.sksamuel.hoplite.Pos
+import com.sksamuel.hoplite.defaultNodeTransformers
+import com.sksamuel.hoplite.defaultParamMappers
+import com.sksamuel.hoplite.fp.Validated
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlin.reflect.full.createType
+
+class InlineClassDecoderTest : StringSpec({
+
+    "should handle illegal argument exceptions gracefully" {
+        val node = LongNode(-1, Pos.NoPos, DotPath.root)
+
+        InlineClassDecoder().decode(
+            node, Port::class.createType(),
+            DecoderContext(defaultDecoderRegistry(), defaultParamMappers(), defaultNodeTransformers())
+        )
+            .shouldBeInstanceOf<Validated.Invalid<ConfigFailure.InvalidConstructorParameters>>()
+            .error.e.shouldBeInstanceOf<IllegalArgumentException>()
+            .message shouldBe "Invalid port: -1"
+    }
+}) {
+    @JvmInline
+    value class Port(val value: Int) {
+        init {
+            require(value in 0..65535) { "Invalid port: $value" }
+        }
+    }
+}


### PR DESCRIPTION
Currently when loading a configuration that would attempt to load a configuration with an `@JvmInline value class` that contains validation (using `require` in `init {}`, the loading will throw the resulting `IllegalArgumentException` instead of handling it gracefully as a `ConfigFailure`.

This works as expected when using a "value" data class (i.e. `data class A(val value: B)`) allowing for in-line usage in the configuration and correctly handling the validation logic. 

```kotlin


@JvmInline
value class PortInline(val value: Int) {
    init {
        require(value in 0..0xFFFF) { "invalid port: $value" }
    }
}

data class PortData(val value: Int) {
    init {
        require(value in 0..0xFFFF) { "invalid port: $value" }
    }
}

class InlineValueCtorSpec() : FreeSpec({
    fun configLoader(source: String, ext: String = "conf") = ConfigLoader { addSource(PropertySource.string(source, ext)) }

    "data 'value' class" - {
        data class Config(val port: PortData)

        "should succeed on valid port" {
            configLoader("port = 1234").loadConfig<Config>()
                .shouldBeInstanceOf<Validated.Valid<Config>>()
                .value.port.value shouldBe 1234
        }

        "should be failure on invalid port" {
            configLoader("port = -1").loadConfig<Config>()
                .shouldBeInstanceOf<Validated.Invalid<ConfigFailure>>()
                .error.description() shouldContain "invalid port: -1"
        }
    }

    "inline class" - {
        data class Config(val port: PortInline)

        "should succeed on valid port" {
            configLoader("port = 1234").loadConfig<Config>()
                .shouldBeInstanceOf<Validated.Valid<Config>>()
                .value.port.value shouldBe 1234
        }

        "should be failure on invalid port" {               // <---- currently fails
            configLoader("port = -1").loadConfig<Config>()
                .shouldBeInstanceOf<Validated.Invalid<ConfigFailure>>()
                .error.description() shouldContain "invalid port: -1"
        }
    }
})
```

This PR replicates the exception handling used in the `DataClassDecoder` into the `InlineClassDecoder`.