### PR TITLE
DataClassDecoder: defer null/undefined handling

### DIFF
--- a/hoplite-core/src/test/kotlin/com/sksamuel/hoplite/PrefixTest.kt
+++ b/hoplite-core/src/test/kotlin/com/sksamuel/hoplite/PrefixTest.kt
@@ -146,5 +146,17 @@ class PrefixTest : FunSpec() {
         config shouldBe TestConfig("A value", 91, listOf("Random13"))
       }
     }
+
+    test("handles defaults with prefixes against an empty config") {
+      data class TestConfig(val a: String = "1")
+
+      val config = ConfigLoaderBuilder.defaultWithoutPropertySources()
+        .addPropertySource(PropertySource.map(emptyMap<String, String>()))
+        .allowEmptyConfigFiles()
+        .build()
+        .loadConfigOrThrow<TestConfig>(prefix = "foo")
+
+      config shouldBe TestConfig("1")
+    }
   }
 }


### PR DESCRIPTION
The `DataClassDecoder` extends the `NullHandlingDecoder`, so with undefined input the data class decoder never actually executes, even if the data class provides defaults -- the `NullHandlingDecoder` kicks out the undefined immediately, resulting in missing config errors.

Prefixes make this much more likely to happen because there is almost always defined (but irrelevant) config at the root e.g. env vars, properties, etc -- thus giving the `DataClassDecoder` a chance to do its thing with defaults -- but prefixed config is much more likely to be completely `Undefined`.

Resolves #480