### PR TITLE
Update aws sdk for kotlin version to 1.4.44

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -96,7 +96,7 @@ dependencyResolutionManagement {
          library("regions", "software.amazon.awssdk:regions:$aws2")
          library("secretsmanager", "software.amazon.awssdk:secretsmanager:$aws2")
 
-         val awsKotlin = "1.3.54"
+         val awsKotlin = "1.4.44"
          library("aws-kotlin-ssm", "aws.sdk.kotlin:ssm:$awsKotlin")
          library("aws-kotlin-secretsmanager", "aws.sdk.kotlin:secretsmanager:$awsKotlin")
 


### PR DESCRIPTION
Updating aws kotlin version to 1.4.44

Ran into an issue where we had an up to date version (1.4.44) of aws sdk for kotlin in a project - for s3 for example - and it caused an issue s.t.
`java.lang.ClassNotFoundException: aws.sdk.kotlin.runtime.http.interceptors.BusinessMetricsInterceptor`

Importing and forcing the ssm and secret manager to a downgraded 1.3.54 provides a workaround for this issue from the importing project's perspective, although caution should be used with other aws services. We only tested with `aws.sdk.kotlin::s3:1.4.44`. 


```
configurations.all {
        resolutionStrategy {
            force("aws.sdk.kotlin::ssm:1.3.54")
            force("aws.sdk.kotlin::secretsmanager:1.3.54")
        }
    }
```

