### PR TITLE
Test watching k8s `ConfigMap` symlinked config paths

### DIFF
--- a/hoplite-watch/src/main/kotlin/com/sksamuel/hoplite/watch/watchers/file.kt
+++ b/hoplite-watch/src/main/kotlin/com/sksamuel/hoplite/watch/watchers/file.kt
@@ -18,6 +18,7 @@ class FileWatcher(private val dir: String) : Watchable {
 
   private fun start() {
     val watchService = FileSystems.getDefault().newWatchService()
+    // we don't use toRealPath() here, because we *want* to watch the symlinked parent the file is in, not the file's real parent
     val pathToWatch = Paths.get(dir).toAbsolutePath()
 
     pathToWatch.register(
@@ -33,7 +34,7 @@ class FileWatcher(private val dir: String) : Watchable {
           val watchKey = watchService.take()
           if (watchKey != null) {
             val events = watchKey.pollEvents()
-            if (events.size > 0) {
+            if (events.isNotEmpty()) {
               cb()
             }
 

--- a/hoplite-watch/src/test/kotlin/com/sksamuel/hoplite/watch/WatcherTest.kt
+++ b/hoplite-watch/src/test/kotlin/com/sksamuel/hoplite/watch/WatcherTest.kt
@@ -11,12 +11,15 @@ import com.sksamuel.hoplite.watch.watchers.FileWatcher
 import io.kotest.assertions.throwables.shouldThrowAny
 import io.kotest.common.ExperimentalKotest
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.engine.spec.tempdir
 import io.kotest.engine.spec.tempfile
 import io.kotest.framework.concurrency.eventually
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.string.shouldContain
 import kotlinx.coroutines.delay
+import java.nio.file.Files
+import java.nio.file.Path
 
 class TestWatcher: Watchable {
   private var cb: (() -> Unit)? = null
@@ -114,6 +117,70 @@ class WatcherTest : FunSpec({
 
     delay(1000)
     tmpFile.writeText("""{"foo": "baz"}""")
+
+    eventually(10000) {
+      val reloadedConfig = reloadableConfig.getLatest()
+      reloadedConfig shouldNotBe null
+      reloadedConfig.foo shouldBe "baz"
+    }
+  }
+
+  /**
+   *  if its a symlink, then we should also watch symlinks for changes, this also supports mounting and watching
+   *  Kubernetes-style ConfigMap resources e.g.
+   *
+   *  # ls -al /mnt/config/
+   *  total 12
+   *  drwxrwxrwx 3 root root 4096 Mar 14 08:46 .
+   *  drwxr-xr-x 1 root root 4096 Mar 14 08:47 ..
+   *  drwxr-xr-x 2 root root 4096 Mar 14 08:46 ..2025_03_14_08_46_21.1272616142
+   *  lrwxrwxrwx 1 root root   32 Mar 14 08:46 ..data -> ..2025_03_14_08_46_21.1272616142
+   *  lrwxrwxrwx 1 root root   25 Mar 14 08:46 foo.yaml -> ..data/foo.yaml
+   *  lrwxrwxrwx 1 root root   20 Mar 14 08:46 bar.yaml -> ..data/bar.yaml
+   *
+   *  Here, Kubernetes creates a new timestamped directory when the ConfigMap changes, and just modifies the ..data symlink to point to it
+   *  FileWatcher raises symlink changes (e.g. overwrite an existing link target on Linux via `ln -sfn`) as ENTRY_CREATE
+   *
+   */
+  test("FileWatcher will reload if a file in the specified symlinked directory changes") {
+    val tmpDir = tempdir("watchertest")
+    val tmpDirPath = tmpDir.toPath()
+    val dataDirRelPath = Path.of("..data")
+    val config1RelPath = Path.of("..config1")
+    val config2RelPath = Path.of("..config2")
+    val configJsonRelPath = Path.of("config.json")
+    val configDataDirPath = tmpDirPath.resolve(dataDirRelPath)
+    val configJsonPath = tmpDirPath.resolve(configJsonRelPath)
+
+    // k8s-style ConfigMap mounting
+    val config1Path = tmpDirPath.resolve(config1RelPath)
+    Files.createDirectory(config1Path)
+    val tmpFile = Files.createFile(config1Path.resolve(configJsonRelPath)).toFile()
+    tmpFile.writeText("""{"foo": "bar"}""")
+
+    Files.createSymbolicLink(configDataDirPath, config1RelPath)
+    Files.createSymbolicLink(configJsonPath, dataDirRelPath.resolve(configJsonRelPath))
+
+    val configLoader = ConfigLoaderBuilder.default()
+      .addSource(PropertySource.file(configJsonPath.toFile()))
+      .build()
+
+    val reloadableConfig = ReloadableConfig(configLoader, TestConfig::class)
+      .addWatcher(FileWatcher(tmpDirPath.toString()))
+
+    val config = reloadableConfig.getLatest()
+    config.foo shouldBe "bar"
+
+    // now simulate ConfigMap symlink replacement
+    val config2Path = tmpDirPath.resolve(config2RelPath)
+    Files.createDirectory(config2Path)
+    val tmpFile2 = Files.createFile(config2Path.resolve(configJsonRelPath)).toFile()
+    tmpFile2.writeText("""{"foo": "baz"}""")
+
+    Files.deleteIfExists(configDataDirPath)
+    Files.createSymbolicLink(configDataDirPath, config2RelPath)
+
+    delay(1000)
 
     eventually(10000) {
       val reloadedConfig = reloadableConfig.getLatest()


### PR DESCRIPTION
Create a test that verifies k8s `ConfigMap` symlinked config paths i.e. when a k8s `ConfigMap` is mounted on a volume are correctly handled by the `FileWatcher`.

This verifies that config reloading will work on Kubernetes with ConfigMap's mounted as volumes.