### PR TITLE
Nested maps use their actual key

### DIFF
--- a/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/parsers/loadProps.kt
+++ b/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/parsers/loadProps.kt
@@ -95,7 +95,8 @@ private fun <T, K> Iterable<T>.toNode(
     )
     is Map<*, *> -> MapNode(
       map = takeUnless { it.isEmpty() }?.mapNotNull { entry ->
-        entry.value?.let { entry.key.toString() to it.transform(path.with(entry.key.toString()), parentSourceKey) }
+        val key = entry.key.toString()
+        entry.value?.let { key to it.transform(path.with(key), key) }
       }?.toMap().orEmpty(),
       pos = pos,
       path = path,

--- a/hoplite-core/src/test/kotlin/com/sksamuel/hoplite/PropertySourceTest.kt
+++ b/hoplite-core/src/test/kotlin/com/sksamuel/hoplite/PropertySourceTest.kt
@@ -125,5 +125,33 @@ class PropertySourceTest : FunSpec() {
         config shouldBe TestConfig("A value", 91, listOf("Random13"))
       }
     }
+
+    test("reads config from nested maps") {
+      data class Foo(
+        val bars: Map<String, String>,
+      )
+
+      data class SomeConfig(
+        val someMap: Map<String, Foo>,
+      )
+
+      val propertySource = PropertySource.map(mapOf(
+        "someMap" to mapOf(
+          "foo" to mapOf(
+            "bars" to mapOf(
+              "bar" to "baz"
+            )
+          )
+        )
+      ))
+
+      val config = ConfigLoaderBuilder
+        .defaultWithoutPropertySources()
+        .addPropertySource(propertySource)
+        .build()
+        .loadConfigOrThrow<SomeConfig>()
+
+      config shouldBe SomeConfig(someMap = mapOf("foo" to Foo(mapOf("bar" to "baz"))))
+    }
   }
 }


### PR DESCRIPTION
Nested maps were being loaded with the parent map's source key. Now they use their actual key.

Resolves #495.