### PR TITLE
Add @ConfigEnumDefault for enum fallback values (#478)

### DIFF
--- a/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/ConfigEnumDefault.kt
+++ b/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/ConfigEnumDefault.kt
@@ -1,0 +1,24 @@
+package com.sksamuel.hoplite
+
+/**
+ * Annotates an enum class with a default value to use when the configured value
+ * does not match any enum constant.
+ *
+ * For example, given the following enum:
+ *
+ * ```
+ * @ConfigEnumDefault("Unknown")
+ * enum class Color { Red, Blue, Green, Unknown }
+ * ```
+ *
+ * a config that supplies `bgColor: Yellow` will decode to `Color.Unknown` instead
+ * of failing with an invalid enum constant error. Useful when consumers may
+ * encounter values produced by newer versions of a system that have not yet been
+ * added to the enum.
+ *
+ * The [name] must match an enum constant declared in the annotated class.
+ * Matching honours the loader's case-insensitive setting.
+ */
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class ConfigEnumDefault(val name: String)

--- a/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/decoder/enum.kt
+++ b/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/decoder/enum.kt
@@ -1,6 +1,7 @@
 package com.sksamuel.hoplite.decoder
 
 import com.sksamuel.hoplite.BooleanNode
+import com.sksamuel.hoplite.ConfigEnumDefault
 import com.sksamuel.hoplite.ConfigFailure
 import com.sksamuel.hoplite.ConfigResult
 import com.sksamuel.hoplite.DecoderContext
@@ -12,6 +13,7 @@ import com.sksamuel.hoplite.fp.invalid
 import com.sksamuel.hoplite.fp.valid
 import kotlin.reflect.KClass
 import kotlin.reflect.KType
+import kotlin.reflect.full.findAnnotation
 
 @Suppress("UNCHECKED_CAST")
 class EnumDecoder<T : Any> : NullHandlingDecoder<T> {
@@ -24,11 +26,15 @@ class EnumDecoder<T : Any> : NullHandlingDecoder<T> {
   ): ConfigResult<T> {
 
     val klass = type.classifier as KClass<*>
+    val ignoreCase = context.config.resolveTypesCaseInsensitive
+
+    fun findConstant(value: String): Any? = klass.java.enumConstants.find {
+      it.toString().contentEquals(other = value, ignoreCase = ignoreCase)
+    }
 
     fun decode(value: String): ConfigResult<T> {
-      val t = klass.java.enumConstants.find {
-        it.toString().contentEquals(other = value, ignoreCase = context.config.resolveTypesCaseInsensitive)
-      }
+      val t = findConstant(value)
+        ?: klass.findAnnotation<ConfigEnumDefault>()?.let { findConstant(it.name) }
       return if (t == null)
         ConfigFailure.InvalidEnumConstant(node, type, value).invalid()
       else

--- a/hoplite-core/src/test/kotlin/com/sksamuel/hoplite/decoder/EnumDecoderTest.kt
+++ b/hoplite-core/src/test/kotlin/com/sksamuel/hoplite/decoder/EnumDecoderTest.kt
@@ -1,5 +1,6 @@
 package com.sksamuel.hoplite.decoder
 
+import com.sksamuel.hoplite.ConfigEnumDefault
 import com.sksamuel.hoplite.ConfigFailure
 import com.sksamuel.hoplite.DecoderConfig
 import com.sksamuel.hoplite.DecoderContext
@@ -12,6 +13,7 @@ import com.sksamuel.hoplite.fp.Validated
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlin.reflect.KType
 import kotlin.reflect.full.createType
 
 class EnumDecoderTest : BehaviorSpec({
@@ -58,6 +60,39 @@ class EnumDecoderTest : BehaviorSpec({
       }
     }
   }
+
+  given("an enum class annotated with @ConfigEnumDefault") {
+    `when`("the configured value does not match any constant") {
+      val node = StringNode("Yellow", Pos.NoPos, DotPath.root)
+      val actual = EnumDecoder<TestEnumWithDefault>().decode(node, TestEnumWithDefault::class.createType())
+
+      then("it should fall back to the default constant") {
+        actual.shouldBeInstanceOf<Validated.Valid<TestEnumWithDefault>>()
+          .value shouldBe TestEnumWithDefault.Unknown
+      }
+    }
+
+    `when`("the configured value matches a real constant") {
+      val node = StringNode("Red", Pos.NoPos, DotPath.root)
+      val actual = EnumDecoder<TestEnumWithDefault>().decode(node, TestEnumWithDefault::class.createType())
+
+      then("it should decode normally without using the fallback") {
+        actual.shouldBeInstanceOf<Validated.Valid<TestEnumWithDefault>>()
+          .value shouldBe TestEnumWithDefault.Red
+      }
+    }
+  }
+
+  given("an enum class annotated with @ConfigEnumDefault naming a missing constant") {
+    `when`("the configured value does not match any constant") {
+      val node = StringNode("Yellow", Pos.NoPos, DotPath.root)
+      val actual = EnumDecoder<TestEnumWithBadDefault>().decode(node, TestEnumWithBadDefault::class.createType())
+
+      then("it should report the original invalid-enum failure") {
+        actual.shouldBeInstanceOf<Validated.Invalid<ConfigFailure>>()
+      }
+    }
+  }
 }) {
   private companion object {
     fun <T : Any> EnumDecoder<T>.decode(node: PrimitiveNode, ignoreCase: Boolean) = decode(
@@ -71,8 +106,29 @@ class EnumDecoderTest : BehaviorSpec({
       )
     )
 
+    fun <T : Any> EnumDecoder<T>.decode(node: PrimitiveNode, type: KType) = decode(
+      node,
+      type,
+      DecoderContext(
+        decoders = defaultDecoderRegistry(),
+        paramMappers = defaultParamMappers(),
+        nodeTransformers = defaultNodeTransformers(),
+        config = DecoderConfig(flattenArraysToString = false, resolveTypesCaseInsensitive = false)
+      )
+    )
+
     enum class TestEnum {
       ONE, TWO
+    }
+
+    @ConfigEnumDefault("Unknown")
+    enum class TestEnumWithDefault {
+      Red, Blue, Green, Unknown
+    }
+
+    @ConfigEnumDefault("DoesNotExist")
+    enum class TestEnumWithBadDefault {
+      Red, Blue
     }
   }
 }

--- a/hoplite-yaml/src/test/kotlin/com/sksamuel/hoplite/decoder/EnumDecoderTest.kt
+++ b/hoplite-yaml/src/test/kotlin/com/sksamuel/hoplite/decoder/EnumDecoderTest.kt
@@ -1,5 +1,6 @@
 package com.sksamuel.hoplite.decoder
 
+import com.sksamuel.hoplite.ConfigEnumDefault
 import com.sksamuel.hoplite.ConfigFailure
 import com.sksamuel.hoplite.ConfigLoaderBuilder
 import com.sksamuel.hoplite.fp.Validated
@@ -8,6 +9,9 @@ import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
+
+@ConfigEnumDefault("Unknown")
+enum class Color { Red, Blue, Green, Unknown }
 
 class EnumDecoderTest : BehaviorSpec({
 
@@ -42,6 +46,32 @@ class EnumDecoderTest : BehaviorSpec({
             it.a shouldBe Wine.Malbec
             it.b shouldBe Wine.Merlot
           }
+      }
+    }
+  }
+
+  given("an enum annotated with @ConfigEnumDefault") {
+    data class Branding(val bgColor: Color)
+
+    `when`("the yaml has an unknown enum value") {
+      val config = ConfigLoaderBuilder.default()
+        .build()
+        .loadConfig<Branding>("/enum_default_invalid.yml")
+
+      then("it falls back to the configured default") {
+        config.shouldBeInstanceOf<Validated.Valid<Branding>>()
+          .value.bgColor shouldBe Color.Unknown
+      }
+    }
+
+    `when`("the yaml has a known enum value") {
+      val config = ConfigLoaderBuilder.default()
+        .build()
+        .loadConfig<Branding>("/enum_default_valid.yml")
+
+      then("it decodes normally") {
+        config.shouldBeInstanceOf<Validated.Valid<Branding>>()
+          .value.bgColor shouldBe Color.Red
       }
     }
   }

--- a/hoplite-yaml/src/test/resources/enum_default_invalid.yml
+++ b/hoplite-yaml/src/test/resources/enum_default_invalid.yml
@@ -1,0 +1,1 @@
+bgColor: Yellow

--- a/hoplite-yaml/src/test/resources/enum_default_valid.yml
+++ b/hoplite-yaml/src/test/resources/enum_default_valid.yml
@@ -1,0 +1,1 @@
+bgColor: Red


### PR DESCRIPTION
Closes #478.

## Summary
Adds a `@ConfigEnumDefault("Unknown")` class-level annotation. When the configured value doesn't match any constant of the annotated enum, the `EnumDecoder` falls back to the named constant instead of failing with `InvalidEnumConstant`.

```kotlin
@ConfigEnumDefault("Unknown")
enum class Color { Red, Blue, Green, Unknown }

data class Branding(val bgColor: Color)
```

```yaml
bgColor: Yellow   # decodes to Color.Unknown instead of erroring
```

This lets consumers keep working when a producer adds a new enum case the consumer hasn't been updated for yet — exactly the scenario described in the issue.

If the annotation names a constant that doesn't exist on the enum, the decoder still reports the original `InvalidEnumConstant` failure rather than silently swallowing it.

## Why class-level rather than parameter-level
The issue sketches a parameter-level annotation (`@ConfigProperty(default = Colors.Unknown)`), but Kotlin annotations can't accept arbitrary enum values via a polymorphic parameter, only specific enum types. Putting the annotation on the class also keeps the fallback semantics where they naturally belong (the enum author defines what "unknown" means) and avoids per-field repetition wherever the enum is used.

## Test plan
- [x] New core unit tests cover: fallback used, fallback not used when value matches, fallback annotation naming a missing constant still surfaces the original failure.
- [x] New end-to-end YAML test mirrors the example from the issue.
- [x] Full `:hoplite-core:test` and `:hoplite-yaml:test` suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)