### PR TITLE
Don't crash on empty-key ${} placeholders (#469)

### DIFF
--- a/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/preprocessor/EnvOrSystemPropertyPreprocessor.kt
+++ b/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/preprocessor/EnvOrSystemPropertyPreprocessor.kt
@@ -19,18 +19,24 @@ object EnvOrSystemPropertyPreprocessor : TraversingPrimitivePreprocessor() {
   private val regex = "\\$\\{(.*?)\\}".toRegex()
   private val valueWithDefaultRegex = "(.*?):-(.*?)".toRegex()
 
+  // System.getProperty throws IllegalArgumentException when called with an empty key,
+  // and that has crashed users whose configs end up containing a literal ${} placeholder
+  // (gh-469). Skip the lookup when the key is empty.
+  private fun lookup(key: String): String? =
+    if (key.isEmpty()) null else System.getProperty(key) ?: System.getenv(key)
+
   override fun handle(node: PrimitiveNode, context: DecoderContext): ConfigResult<Node> = when (node) {
     is StringNode -> {
       val rawValue = node.value
       val value = regex.replace(rawValue) { match ->
         val key = match.groupValues[1]
         when (val matchWithDefault = valueWithDefaultRegex.matchEntire(key)) {
-          null -> System.getProperty(key) ?: System.getenv(key) ?: match.value
+          null -> lookup(key) ?: match.value
           // lookup with default value fallback
           else -> matchWithDefault.let { m ->
             val key2 = m.groupValues[1]
             val default = m.groupValues[2]
-            System.getProperty(key2) ?: System.getenv(key2) ?: default
+            lookup(key2) ?: default
           }
         }
       }

--- a/hoplite-yaml/src/test/kotlin/com/sksamuel/hoplite/yaml/EnvVarPreprocessorTest.kt
+++ b/hoplite-yaml/src/test/kotlin/com/sksamuel/hoplite/yaml/EnvVarPreprocessorTest.kt
@@ -57,5 +57,24 @@ class EnvVarPreprocessorTest : FunSpec() {
           .loadConfigOrThrow<Test>()
       }.message.shouldContain("Unresolved substitution \${wibble}")
     }
+
+    // gh-469
+    test("empty placeholder \${} should not crash and is reported as unresolved") {
+      data class Test(val a: String)
+      shouldThrowAny {
+        ConfigLoader.builder()
+          .addSource(YamlPropertySource("a: \"prefix-\${}-suffix\""))
+          .build()
+          .loadConfigOrThrow<Test>()
+      }.message.shouldContain("Unresolved substitution")
+    }
+
+    test("empty placeholder with default \${:-fallback} should resolve to the default") {
+      data class Test(val a: String)
+      ConfigLoader.builder()
+        .addSource(YamlPropertySource("a: \${:-fallback}"))
+        .build()
+        .loadConfigOrThrow<Test>() shouldBe Test(a = "fallback")
+    }
   }
 }


### PR DESCRIPTION
Closes #469.

## Summary
`EnvOrSystemPropertyPreprocessor` calls `System.getProperty(key)` for every `\${...}` it finds in a config string. `System.getProperty` throws `IllegalArgumentException: key can't be empty` when the key is empty, so any config that ends up containing a literal `\${}` (or `\${:-default}` with no key) crashes the loader before the validator can produce a useful error — exactly the failure the OSS Review Toolkit user hit.

Fix: factor the lookup into a helper that short-circuits to `null` for an empty key.

- `\${}` is left as-is so the existing `UnresolvedSubstitutionChecker` reports it as an unresolved substitution rather than crashing.
- `\${:-fallback}` resolves to `fallback`, matching the documented "use the default if the key isn't set" semantics.

## Test plan
- [x] New `EnvVarPreprocessorTest` cases cover both branches (empty key with no default → unresolved-substitution failure; empty key with default → default returned).
- [x] Existing `:hoplite-core:test` and `:hoplite-yaml:test` suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)