### PR TITLE
Add tests confirming decoder bug fixes from #519

### DIFF
--- a/hoplite-arrow/src/test/kotlin/com/sksamuel/hoplite/arrow/NonEmptyListTest.kt
+++ b/hoplite-arrow/src/test/kotlin/com/sksamuel/hoplite/arrow/NonEmptyListTest.kt
@@ -2,6 +2,8 @@ package com.sksamuel.hoplite.arrow
 
 import arrow.core.nonEmptyListOf
 import com.sksamuel.hoplite.ConfigLoader
+import com.sksamuel.hoplite.ConfigLoaderBuilder
+import com.sksamuel.hoplite.yaml.YamlPropertySource
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 
@@ -12,6 +14,50 @@ class NonEmptyListTest : FunSpec({
 
     val config = ConfigLoader().loadConfigOrThrow<Test>("/test_nel.yml")
     config shouldBe Test(nonEmptyListOf("1", "2", "a", "b"), nonEmptyListOf(1L, 2L, 3L, 4L))
+  }
+
+  // Per-element decoders must be invoked with the element KType, not the outer
+  // NonEmptyList<T> KType, otherwise nested decoders that read type.arguments break.
+  test("NonEmptyList<DataClass> passes element type to data class decoder") {
+    data class Item(val name: String, val score: Int)
+    data class Test(val items: arrow.core.NonEmptyList<Item>)
+
+    val config = ConfigLoaderBuilder.default()
+      .addPropertySource(
+        YamlPropertySource(
+          """
+            items:
+              - name: alice
+                score: 1
+              - name: bob
+                score: 2
+          """
+        )
+      )
+      .build()
+      .loadConfigOrThrow<Test>()
+
+    config shouldBe Test(nonEmptyListOf(Item("alice", 1), Item("bob", 2)))
+  }
+
+  test("NonEmptyList<Map<String, Int>> passes element type to map decoder") {
+    data class Test(val items: arrow.core.NonEmptyList<Map<String, Int>>)
+
+    val config = ConfigLoaderBuilder.default()
+      .addPropertySource(
+        YamlPropertySource(
+          """
+            items:
+              - a: 1
+                b: 2
+              - c: 3
+          """
+        )
+      )
+      .build()
+      .loadConfigOrThrow<Test>()
+
+    config shouldBe Test(nonEmptyListOf(mapOf("a" to 1, "b" to 2), mapOf("c" to 3)))
   }
 
 })

--- a/hoplite-vavr/src/test/kotlin/com/sksamuel/hoplite/decoder/vavr/ListDecoderTest.kt
+++ b/hoplite-vavr/src/test/kotlin/com/sksamuel/hoplite/decoder/vavr/ListDecoderTest.kt
@@ -1,6 +1,8 @@
 package com.sksamuel.hoplite.decoder.vavr
 
 import com.sksamuel.hoplite.ConfigLoader
+import com.sksamuel.hoplite.ConfigLoaderBuilder
+import com.sksamuel.hoplite.yaml.YamlPropertySource
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.vavr.collection.List
@@ -13,6 +15,50 @@ class ListDecoderTest : FunSpec({
 
     val config = ConfigLoader().loadConfigOrThrow<Test>("/test_list.yml")
     config shouldBe Test(list("test1", "test2", "test3"))
+  }
+
+  // Per-element decoders must be invoked with the element KType, not the outer
+  // List<T> KType, otherwise nested decoders that read type.arguments break.
+  test("List<Map<String, Int>> passes element type to map decoder") {
+    data class Test(val items: List<Map<String, Int>>)
+
+    val config = ConfigLoaderBuilder.default()
+      .addPropertySource(
+        YamlPropertySource(
+          """
+            items:
+              - a: 1
+                b: 2
+              - c: 3
+          """
+        )
+      )
+      .build()
+      .loadConfigOrThrow<Test>()
+
+    config shouldBe Test(list(mapOf("a" to 1, "b" to 2), mapOf("c" to 3)))
+  }
+
+  test("List<DataClass> passes element type to data class decoder") {
+    data class Item(val name: String, val score: Int)
+    data class Test(val items: List<Item>)
+
+    val config = ConfigLoaderBuilder.default()
+      .addPropertySource(
+        YamlPropertySource(
+          """
+            items:
+              - name: alice
+                score: 1
+              - name: bob
+                score: 2
+          """
+        )
+      )
+      .build()
+      .loadConfigOrThrow<Test>()
+
+    config shouldBe Test(list(Item("alice", 1), Item("bob", 2)))
   }
 
 })

--- a/hoplite-vavr/src/test/kotlin/com/sksamuel/hoplite/decoder/vavr/SortedSetDecoderTest.kt
+++ b/hoplite-vavr/src/test/kotlin/com/sksamuel/hoplite/decoder/vavr/SortedSetDecoderTest.kt
@@ -1,10 +1,17 @@
 package com.sksamuel.hoplite.decoder.vavr
 
 import com.sksamuel.hoplite.ConfigLoader
+import com.sksamuel.hoplite.ConfigLoaderBuilder
+import com.sksamuel.hoplite.yaml.YamlPropertySource
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.vavr.collection.SortedSet
+import io.vavr.collection.TreeSet
 import io.vavr.kotlin.treeSet
+
+data class VavrSortedSetItem(val name: String, val score: Int) : Comparable<VavrSortedSetItem> {
+  override fun compareTo(other: VavrSortedSetItem): Int = name.compareTo(other.name)
+}
 
 class SortedSetDecoderTest : FunSpec({
 
@@ -13,6 +20,29 @@ class SortedSetDecoderTest : FunSpec({
 
     val config = ConfigLoader().loadConfigOrThrow<Test>("/test_set.yml")
     config shouldBe Test(treeSet(3, 2, 1))
+  }
+
+  // Per-element decoders must be invoked with the element KType, not the outer
+  // SortedSet<T> KType — DataClassDecoder reads type.classifier.
+  test("SortedSet<DataClass> passes element type to data class decoder") {
+    data class Test(val items: SortedSet<VavrSortedSetItem>)
+
+    val config = ConfigLoaderBuilder.default()
+      .addPropertySource(
+        YamlPropertySource(
+          """
+            items:
+              - name: alice
+                score: 1
+              - name: bob
+                score: 2
+          """
+        )
+      )
+      .build()
+      .loadConfigOrThrow<Test>()
+
+    config shouldBe Test(TreeSet.of(VavrSortedSetItem("alice", 1), VavrSortedSetItem("bob", 2)))
   }
 
 })

--- a/hoplite-yaml/src/test/kotlin/com/sksamuel/hoplite/decoder/BasicDecodersTest.kt
+++ b/hoplite-yaml/src/test/kotlin/com/sksamuel/hoplite/decoder/BasicDecodersTest.kt
@@ -1,6 +1,8 @@
 package com.sksamuel.hoplite.decoder
 
 import com.sksamuel.hoplite.ConfigLoader
+import com.sksamuel.hoplite.ConfigLoaderBuilder
+import com.sksamuel.hoplite.yaml.YamlPropertySource
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import java.math.BigDecimal
@@ -94,5 +96,27 @@ class BasicTypesTest : FunSpec({
 
     val config = ConfigLoader().loadConfigOrThrow<Test>("/test_biginteger.yml")
     config shouldBe Test(BigInteger.valueOf(10000L))
+  }
+
+  test("BigInteger preserves precision beyond Long range") {
+    data class Test(val a: BigInteger)
+
+    val huge = "99999999999999999999"
+    val config = ConfigLoaderBuilder.default()
+      .addPropertySource(YamlPropertySource("a: \"$huge\""))
+      .build()
+      .loadConfigOrThrow<Test>()
+    config shouldBe Test(BigInteger(huge))
+  }
+
+  test("BigDecimal preserves precision beyond Double") {
+    data class Test(val a: BigDecimal)
+
+    val precise = "0.123456789012345678901234567"
+    val config = ConfigLoaderBuilder.default()
+      .addPropertySource(YamlPropertySource("a: \"$precise\""))
+      .build()
+      .loadConfigOrThrow<Test>()
+    config shouldBe Test(BigDecimal(precise))
   }
 })

--- a/hoplite-yaml/src/test/kotlin/com/sksamuel/hoplite/decoder/CollectionDecodersTest.kt
+++ b/hoplite-yaml/src/test/kotlin/com/sksamuel/hoplite/decoder/CollectionDecodersTest.kt
@@ -1,8 +1,16 @@
 package com.sksamuel.hoplite.decoder
 
 import com.sksamuel.hoplite.ConfigLoader
+import com.sksamuel.hoplite.ConfigLoaderBuilder
+import com.sksamuel.hoplite.yaml.YamlPropertySource
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
+import java.util.SortedSet
+import java.util.TreeSet
+
+data class CoreSortedSetItem(val name: String, val score: Int) : Comparable<CoreSortedSetItem> {
+  override fun compareTo(other: CoreSortedSetItem): Int = name.compareTo(other.name)
+}
 
 class CollectionDecodersTest : FunSpec() {
   init {
@@ -53,6 +61,34 @@ class CollectionDecodersTest : FunSpec() {
 
       val config = ConfigLoader().loadConfigOrThrow<Test>("/basic.yml")
       config shouldBe Test(null, null)
+    }
+
+    // Per-element decoders must be invoked with the element KType, not the outer
+    // SortedSet<T> KType — DataClassDecoder reads type.classifier.
+    test("SortedSet<DataClass> passes element type to data class decoder") {
+      data class Test(val items: SortedSet<CoreSortedSetItem>)
+
+      val config = ConfigLoaderBuilder.default()
+        .addPropertySource(
+          YamlPropertySource(
+            """
+              items:
+                - name: alice
+                  score: 1
+                - name: bob
+                  score: 2
+            """
+          )
+        )
+        .build()
+        .loadConfigOrThrow<Test>()
+
+      config shouldBe Test(
+        TreeSet<CoreSortedSetItem>().apply {
+          add(CoreSortedSetItem("alice", 1))
+          add(CoreSortedSetItem("bob", 2))
+        }
+      )
     }
   }
 }


### PR DESCRIPTION
## Summary

Follow-up to #519 (already merged). Adds regression tests that lock in the two classes of decoder bugs fixed there:

- **BigInteger / BigDecimal precision** — assert that strings exceeding Long and Double range round-trip without loss. These would fail under the previous `toLong()` / `toDouble()` conversions.

- **Collection element-type passthrough** — assert that `SortedSet` (core), `List` / `SortedSet` (vavr), and `NonEmptyList` (arrow) invoke the per-element decoder with the *element* `KType`, not the outer container `KType`. Verified by nesting a data class or `Map<String, Int>` as the element type, since those decoders read `type.arguments` / `type.classifier` and would fail with the wrong `KType`.

I confirmed each test fails on the pre-#519 source before passing on master.

## Test plan
- [x] `./gradlew :hoplite-core:test :hoplite-yaml:test :hoplite-arrow:test :hoplite-vavr:test` — passes
- [x] All five new tests fail with #519 reverted, pass with #519 applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)