### PR TITLE
Don't flag env vars or sysprops as unused in strict() mode (#505)

### DIFF
--- a/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/internal/DecodeModeValidator.kt
+++ b/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/internal/DecodeModeValidator.kt
@@ -2,6 +2,7 @@ package com.sksamuel.hoplite.internal
 
 import com.sksamuel.hoplite.ConfigFailure
 import com.sksamuel.hoplite.ConfigResult
+import com.sksamuel.hoplite.DecodedPath
 import com.sksamuel.hoplite.fp.NonEmptyList
 import com.sksamuel.hoplite.fp.invalid
 import com.sksamuel.hoplite.fp.valid
@@ -19,10 +20,21 @@ class DecodeModeValidator(private val mode: DecodeMode) {
   }
 
   private fun ensureAllUsed(result: DecodingState): ConfigResult<DecodingState> {
-    return if (result.unused.isEmpty()) result.valid() else {
-      val errors = NonEmptyList.unsafe(result.unused.map { ConfigFailure.UnusedPath(it) })
+    val unused = result.unused.filterNot { it.isExternalSource() }
+    return if (unused.isEmpty()) result.valid() else {
+      val errors = NonEmptyList.unsafe(unused.map { ConfigFailure.UnusedPath(it) })
       ConfigFailure.MultipleFailures(errors).invalid()
     }
+  }
+
+  // Process-wide sources (environment variables, JVM system properties) typically contain values
+  // the loader did not request — HOME, USER, TMPDIR, etc. for env vars, and arbitrary JVM
+  // properties for sysprops. Reporting them as "unused" in strict mode produces noise that has
+  // nothing to do with the user's config files (gh-505). Strict mode still catches stale values
+  // in user-provided sources (yaml, json, hocon, props, map sources, ...).
+  private fun DecodedPath.isExternalSource(): Boolean = when (pos.source()) {
+    "env", "sysprops" -> true
+    else -> false
   }
 }
 

--- a/hoplite-core/src/test/kotlin/com/sksamuel/hoplite/StrictModeEnvVarsTest.kt
+++ b/hoplite-core/src/test/kotlin/com/sksamuel/hoplite/StrictModeEnvVarsTest.kt
@@ -1,0 +1,66 @@
+package com.sksamuel.hoplite
+
+import com.sksamuel.hoplite.sources.EnvironmentVariablesPropertySource
+import com.sksamuel.hoplite.sources.SystemPropertiesPropertySource
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
+
+class StrictModeEnvVarsTest : FunSpec({
+
+  data class TestConfig(val name: String)
+
+  // gh-505: process-wide environment variables (HOME, USER, TMPDIR, ...) should never be
+  // reported as unused in strict mode — strict is meant to catch stale values in user-provided
+  // config, not noise from the OS.
+  test("strict mode should ignore unused environment variables") {
+    val config = ConfigLoaderBuilder.default()
+      .addMapSource(mapOf("name" to "test"))
+      .strict()
+      .build()
+      .loadConfigOrThrow<TestConfig>()
+
+    config.name shouldBe "test"
+  }
+
+  test("strict mode should ignore env vars supplied to a custom EnvironmentVariablesPropertySource") {
+    val config = ConfigLoaderBuilder.defaultWithoutPropertySources()
+      .addPropertySource(EnvironmentVariablesPropertySource(
+        environmentVariableMap = { mapOf("name" to "test", "OTHER" to "noise") },
+      ))
+      .strict()
+      .build()
+      .loadConfigOrThrow<TestConfig>()
+
+    config.name shouldBe "test"
+  }
+
+  test("strict mode should ignore unused JVM system properties") {
+    val config = ConfigLoaderBuilder.defaultWithoutPropertySources()
+      .addPropertySource(SystemPropertiesPropertySource {
+        mapOf("config.override.unused" to "noise")
+      })
+      .addMapSource(mapOf("name" to "test"))
+      .strict()
+      .build()
+      .loadConfigOrThrow<TestConfig>()
+
+    config.name shouldBe "test"
+  }
+
+  test("strict mode still flags unused values from user-provided map sources") {
+    val ex = shouldThrow<ConfigException> {
+      ConfigLoaderBuilder.default()
+        .addMapSource(mapOf("name" to "test", "stale" to "value"))
+        .strict()
+        .build()
+        .loadConfigOrThrow<TestConfig>()
+    }
+    ex.message
+      .shouldContain("Config value 'stale'")
+      .shouldNotContain("Config value 'HOME'")
+      .shouldNotContain("Config value 'USER'")
+  }
+})


### PR DESCRIPTION
Closes #505.

## Summary
`strict()` mode is meant to surface stale values in user-provided config (yaml/json/hocon/props/map sources). The default `EnvironmentVariablesPropertySource` and `SystemPropertiesPropertySource` pull in process-wide values the loader never asked for — `HOME`, `USER`, `TMPDIR`, `PYENV`, `LC_CTYPE`, etc. — and `strict()` then refused to load any config at all because every one of those was reported as unused.

Per the discussion on the issue, this is the case-2 behaviour (the most common): the user wants strict to catch stale yaml/json keys, and there's no way to enumerate the env vars on a developer/Kubernetes host up front. A future opt-in could cover the case-3 "I want strict-strict including env" use case, but that's a separate change.

Fix: filter out unused decoded paths whose `Pos.SourcePos.source` is `"env"` or `"sysprops"` before reporting `UnusedPath` failures. Strict mode still flags every other source.

## Test plan
- [x] New `StrictModeEnvVarsTest` reproduces the exact snippet from the issue, plus coverage for a custom `EnvironmentVariablesPropertySource`, sysprops via `config.override.*`, and a regression test confirming unused values from a `MapPropertySource` are still flagged.
- [x] Existing strict-mode tests in `:hoplite-core` and `:hoplite-yaml` still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)