### PR TITLE
Stop legacy preprocessors from mangling ${{...}} (#472)

### DIFF
--- a/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/preprocessor/EnvOrSystemPropertyPreprocessor.kt
+++ b/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/preprocessor/EnvOrSystemPropertyPreprocessor.kt
@@ -12,11 +12,15 @@ import com.sksamuel.hoplite.fp.valid
 /**
  * Replaces strings of the form ${var} with the value of the env variable 'var' or system property 'var'.
  * Defaults can also be applied in case the env var is not available: ${var:-default}.
+ *
+ * The negative-lookahead `(?!\{)` skips `${{...}}` placeholders so this legacy preprocessor does not
+ * mangle context-resolver syntax such as `${{ env:VAR :- fallback }}` (gh-472), which the regex would
+ * otherwise greedily match through the inner `{` and the first `}`.
  */
 object EnvOrSystemPropertyPreprocessor : TraversingPrimitivePreprocessor() {
 
   // Redundant escaping required for Android support.
-  private val regex = "\\$\\{(.*?)\\}".toRegex()
+  private val regex = "\\$\\{(?!\\{)(.*?)\\}".toRegex()
   private val valueWithDefaultRegex = "(.*?):-(.*?)".toRegex()
 
   override fun handle(node: PrimitiveNode, context: DecoderContext): ConfigResult<Node> = when (node) {

--- a/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/preprocessor/LookupPreprocessor.kt
+++ b/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/preprocessor/LookupPreprocessor.kt
@@ -19,10 +19,13 @@ import com.sksamuel.hoplite.withMeta
 object LookupPreprocessor : Preprocessor {
 
   // Redundant escaping required for Android support.
-  private val regex1 = "\\$\\{(.*?)\\}".toRegex()
+  // The `(?!\{)` skips `${{...}}` placeholders so this preprocessor does not mangle context-resolver
+  // syntax such as `${{ env:VAR :- fallback }}` (gh-472).
+  private val regex1 = "\\$\\{(?!\\{)(.*?)\\}".toRegex()
 
   // react syntax {{a.b.c}}
-  private val regex2 = "\\{\\{(.*?)\\}\\}".toRegex()
+  // The `(?<!\$)` skips `${{...}}` (which is context-resolver syntax, handled elsewhere).
+  private val regex2 = "(?<!\\$)\\{\\{(.*?)\\}\\}".toRegex()
   private val valueWithDefaultRegex = "(.*?):-(.*?)".toRegex()
 
   override fun process(node: Node, context: DecoderContext): ConfigResult<Node> {

--- a/hoplite-core/src/test/kotlin/com/sksamuel/hoplite/Gh472ReproTest.kt
+++ b/hoplite-core/src/test/kotlin/com/sksamuel/hoplite/Gh472ReproTest.kt
@@ -1,0 +1,64 @@
+package com.sksamuel.hoplite
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.extensions.system.withEnvironment
+import io.kotest.matchers.shouldBe
+
+@OptIn(ExperimentalHoplite::class)
+class Gh472ReproTest : FunSpec({
+
+  data class Cfg(val bootstrapServers: String)
+
+  // gh-472: when the env var is missing the fallback should be returned, not the raw expression.
+  // The reporter's tight syntax has no spaces around `:-`.
+  test("env-var fallback should kick in when env var is missing (no spaces around :-)") {
+    withEnvironment(emptyMap()) {
+      val cfg = ConfigLoaderBuilder.newBuilderWithoutPropertySources()
+        .addMapSource(mapOf("bootstrapServers" to "\${{ env:BOOTSTRAPSERVERS_GH472:-fallback }}"))
+        .build()
+        .loadConfigOrThrow<Cfg>()
+
+      cfg.bootstrapServers shouldBe "fallback"
+    }
+  }
+
+  test("env-var fallback should kick in when env var is missing (with spaces around :-)") {
+    withEnvironment(emptyMap()) {
+      val cfg = ConfigLoaderBuilder.newBuilderWithoutPropertySources()
+        .addMapSource(mapOf("bootstrapServers" to "\${{ env:BOOTSTRAPSERVERS_GH472 :- fallback }}"))
+        .build()
+        .loadConfigOrThrow<Cfg>()
+
+      cfg.bootstrapServers shouldBe "fallback"
+    }
+  }
+
+  test("env-var resolution still works when the env var is set") {
+    withEnvironment(mapOf("BOOTSTRAPSERVERS_GH472" to "real-value")) {
+      val cfg = ConfigLoaderBuilder.newBuilderWithoutPropertySources()
+        .addMapSource(mapOf("bootstrapServers" to "\${{ env:BOOTSTRAPSERVERS_GH472:-fallback }}"))
+        .build()
+        .loadConfigOrThrow<Cfg>()
+
+      cfg.bootstrapServers shouldBe "real-value"
+    }
+  }
+
+  // Even if a user is still on the legacy preprocessor pipeline, the EnvOrSystemPropertyPreprocessor
+  // and LookupPreprocessor must not mangle context-resolver syntax (`${{...}}`). Before the fix,
+  // EnvOrSystemPropertyPreprocessor's `${(.*?)}` regex greedily consumed the inner `{` and the first
+  // `}`, replacing `${{ env:VAR:-fallback }}` with `fallback }` — silently corrupting the value
+  // before any resolver got a chance.
+  test("legacy preprocessors must not mangle \${{...}} context-resolver syntax") {
+    withEnvironment(emptyMap()) {
+      val raw = "\${{ env:BOOTSTRAPSERVERS_GH472:-fallback }}"
+      val cfg = ConfigLoaderBuilder.defaultWithoutPropertySources()
+        .addMapSource(mapOf("bootstrapServers" to raw))
+        .allowUnresolvedSubstitutions()
+        .build()
+        .loadConfigOrThrow<Cfg>()
+
+      cfg.bootstrapServers shouldBe raw
+    }
+  }
+})


### PR DESCRIPTION
Closes #472.

## Root cause
`EnvOrSystemPropertyPreprocessor` and `LookupPreprocessor` use regexes that match `${...}` (non-greedy) — and `LookupPreprocessor` also `{{...}}`. When applied to context-resolver syntax like `${{ env:BOOTSTRAPSERVERS:-fallback }}`, these regexes eagerly match through the inner `{` and the first `}`, leaving the trailing `}` behind. The legacy code then runs a doomed lookup with the bogus key `{ env:BOOTSTRAPSERVERS` and "succeeds" with the default branch — so the value is silently rewritten to `fallback }` long before any context resolver runs.

The reporter was hit by exactly this corruption pattern: env var unset → fallback path engaged on a malformed key → garbled output.

## Fix
Teach the legacy regexes that `${{...}}` is context-resolver syntax and they should leave it alone:

- `EnvOrSystemPropertyPreprocessor`: `\${(?!\{)(.*?)\}` — negative lookahead skips a leading `{`.
- `LookupPreprocessor` regex1 (`\${...}`): same negative lookahead.
- `LookupPreprocessor` regex2 (`{{...}}`): `(?<!\$)\{\{(.*?)\}\}` — negative lookbehind skips a preceding `$`.

Plain `${var}`, `${var:-default}`, and `{{a.b.c}}` still substitute as before.

## Test plan
- [x] New `Gh472ReproTest` covers: missing env var with the reporter's exact tight `:-fallback` syntax, the spaced `:- fallback` variant, the env-var-set happy path, and a regression test confirming the legacy preprocessor pipeline now leaves `${{...}}` untouched (so a downstream context resolver can handle it).
- [x] `:hoplite-core`, `:hoplite-yaml`, `:hoplite-hocon`, `:hoplite-json` test suites all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)