### PR TITLE
Fix ${random.double} returning a Long instead of a Double

### DIFF
--- a/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/preprocessor/RandomPreprocessor.kt
+++ b/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/preprocessor/RandomPreprocessor.kt
@@ -54,7 +54,7 @@ object RandomPreprocessor : TraversingPrimitivePreprocessor() {
 
   private val doubleRule: Rule = {
     val regex = "\\$\\{random.double\\}".toRegex()
-    regex.replace(it) { Random.nextLong().toString() }
+    regex.replace(it) { Random.nextDouble().toString() }
   }
 
   private val stringRule: Rule = {

--- a/hoplite-core/src/test/kotlin/com/sksamuel/hoplite/preprocessor/RandomPreprocessorTest.kt
+++ b/hoplite-core/src/test/kotlin/com/sksamuel/hoplite/preprocessor/RandomPreprocessorTest.kt
@@ -1,0 +1,23 @@
+package com.sksamuel.hoplite.preprocessor
+
+import com.sksamuel.hoplite.ConfigLoaderBuilder
+import com.sksamuel.hoplite.addMapSource
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.doubles.shouldBeBetween
+
+class RandomPreprocessorTest : FunSpec({
+
+  // RandomPreprocessor.doubleRule was substituting Random.nextLong() instead of nextDouble(),
+  // so `${random.double}` produced an integer (rejected by Double decoders that strict-parse,
+  // and semantically wrong for code that relied on a uniform [0, 1) value).
+  test("\${random.double} should produce a value in [0, 1)") {
+    data class Cfg(val v: Double)
+
+    val cfg = ConfigLoaderBuilder.defaultWithoutPropertySources()
+      .addMapSource(mapOf("v" to "\${random.double}"))
+      .build()
+      .loadConfigOrThrow<Cfg>()
+
+    cfg.v.shouldBeBetween(0.0, 1.0, 0.0)
+  }
+})


### PR DESCRIPTION
## Summary
\`RandomPreprocessor.doubleRule\` called \`Random.nextLong()\` inside its replacement lambda, so \`\${random.double}\` substituted in an integer string. Switched to \`Random.nextDouble()\`.

## Test plan
- [x] New \`RandomPreprocessorTest\` asserts \`\${random.double}\` decodes to a value in \`[0, 1)\`. Fails before the fix, passes after.
- [x] \`:hoplite-core:test\` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)