### PR TITLE
Fix RandomContextResolver parameterised paths never matching

### DIFF
--- a/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/resolver/context/RandomContextResolver.kt
+++ b/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/resolver/context/RandomContextResolver.kt
@@ -17,9 +17,13 @@ object RandomContextResolver : ContextResolver() {
   override val contextKey: String = "random"
   override val default: Boolean = false
 
-  private val intWithMaxRule = "\\$\\{random.int\\(\\s*(\\d+)\\s*\\)\\}".toRegex()
-  private val intWithRangeRule = "\\$\\{random.int\\(\\s*(\\d+)\\s*,\\s*(\\d+)\\s*\\)\\}".toRegex()
-  private val stringRule = "\\$\\{random.string\\(\\s*(\\d+)\\s*\\)\\}".toRegex()
+  // The path passed to lookup() is just the inside of `${{ random:... }}` — e.g. `int(10)` —
+  // not the surrounding `${random.int(10)}` syntax. The previous regexes were anchored to the
+  // outer form, so they could never match and `${{ random:int(N) }}` and friends fell through to
+  // null, leaving the placeholder unresolved.
+  private val intWithMaxRule = "int\\(\\s*(\\d+)\\s*\\)".toRegex()
+  private val intWithRangeRule = "int\\(\\s*(\\d+)\\s*,\\s*(\\d+)\\s*\\)".toRegex()
+  private val stringRule = "string\\(\\s*(\\d+)\\s*\\)".toRegex()
 
   override fun lookup(path: String, node: StringNode, root: Node, context: DecoderContext): ConfigResult<String?> {
     return when (path) {

--- a/hoplite-core/src/test/kotlin/com/sksamuel/hoplite/resolver/context/RandomContextResolverTest.kt
+++ b/hoplite-core/src/test/kotlin/com/sksamuel/hoplite/resolver/context/RandomContextResolverTest.kt
@@ -1,0 +1,49 @@
+package com.sksamuel.hoplite.resolver.context
+
+import com.sksamuel.hoplite.ConfigLoaderBuilder
+import com.sksamuel.hoplite.ExperimentalHoplite
+import com.sksamuel.hoplite.addMapSource
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.ints.shouldBeGreaterThanOrEqual
+import io.kotest.matchers.ints.shouldBeInRange
+import io.kotest.matchers.ints.shouldBeLessThan
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldMatch
+
+@OptIn(ExperimentalHoplite::class)
+class RandomContextResolverTest : FunSpec({
+
+  fun loader(map: Map<String, Any>) = ConfigLoaderBuilder.newBuilderWithoutPropertySources()
+    .addMapSource(map)
+    .build()
+
+  // The simple paths (int / long / double / uuid / boolean) had always worked because they hit
+  // the literal `when (path)` branch. The parameterised paths went through regexes that were
+  // anchored to the outer `${random.int(N)}` form, so they never matched the inner path string
+  // and the placeholders were left unresolved.
+  test("\${{ random:int(N) }} returns an int in [0, N)") {
+    data class Cfg(val v: Int)
+    val cfg = loader(mapOf("v" to "\${{ random:int(10) }}")).loadConfigOrThrow<Cfg>()
+    cfg.v.shouldBeInRange(0..9)
+  }
+
+  test("\${{ random:int(M, N) }} returns an int in [M, N)") {
+    data class Cfg(val v: Int)
+    val cfg = loader(mapOf("v" to "\${{ random:int(100, 200) }}")).loadConfigOrThrow<Cfg>()
+    cfg.v.shouldBeGreaterThanOrEqual(100)
+    cfg.v.shouldBeLessThan(200)
+  }
+
+  test("\${{ random:string(N) }} returns a lower-case alpha string of length N") {
+    data class Cfg(val v: String)
+    val cfg = loader(mapOf("v" to "\${{ random:string(12) }}")).loadConfigOrThrow<Cfg>()
+    cfg.v shouldMatch Regex("^[a-z]{12}$")
+  }
+
+  // Smoke test for the simple paths so all the random-context paths are covered together.
+  test("\${{ random:boolean }} returns a boolean") {
+    data class Cfg(val v: Boolean)
+    val cfg = loader(mapOf("v" to "\${{ random:boolean }}")).loadConfigOrThrow<Cfg>()
+    (cfg.v == true || cfg.v == false) shouldBe true
+  }
+})


### PR DESCRIPTION
## Summary
\`RandomContextResolver\` exposes \`\${{ random:int(N) }}\`, \`\${{ random:int(M, N) }}\`, and \`\${{ random:string(N) }}\` placeholders. The implementation routes each one through a regex \`matchEntire\` against the inner path string, but the regexes were anchored to the outer \`\${random.int(N)}\` syntax — so they never matched the actual path values like \`int(10)\`, every parameterised placeholder fell through to \`null\`, and resolution failed (or left the placeholder literal in place if the resolver mode allowed it).

Fix: anchor the regexes to just the inner form (\`int\\(\\s*(\\d+)\\s*\\)\`, etc.) so they fire.

The literal-path branches (\`int\`, \`long\`, \`double\`, \`uuid\`, \`boolean\`) always worked because they hit the \`when (path)\` branch directly — those are unchanged.

## Test plan
- [x] New \`RandomContextResolverTest\` covers \`\${{ random:int(N) }}\`, \`\${{ random:int(M, N) }}\`, \`\${{ random:string(N) }}\`, plus a smoke test for the literal-path \`\${{ random:boolean }}\`. Fails before the fix, passes after.
- [x] \`:hoplite-core:test\` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)