### PR TITLE
Fix ${{ hoplite:env }} returning the host CPU count

### DIFF
--- a/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/resolver/context/HopliteContextResolver.kt
+++ b/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/resolver/context/HopliteContextResolver.kt
@@ -22,8 +22,8 @@ object HopliteContextResolver : ContextResolver() {
 
   override fun lookup(path: String, node: StringNode, root: Node, context: DecoderContext): ConfigResult<String?> {
     return when (path) {
-      "env" -> Runtime.getRuntime().availableProcessors().toString().valid()
-      else -> ConfigFailure.ResolverFailure("Uknown hoplite context path $path").invalid()
+      "env", "environment" -> context.environment?.name.valid()
+      else -> ConfigFailure.ResolverFailure("Unknown hoplite context path $path").invalid()
     }
   }
 }

--- a/hoplite-core/src/test/kotlin/com/sksamuel/hoplite/resolver/context/HopliteContextResolverTest.kt
+++ b/hoplite-core/src/test/kotlin/com/sksamuel/hoplite/resolver/context/HopliteContextResolverTest.kt
@@ -1,0 +1,38 @@
+package com.sksamuel.hoplite.resolver.context
+
+import com.sksamuel.hoplite.ConfigLoaderBuilder
+import com.sksamuel.hoplite.ExperimentalHoplite
+import com.sksamuel.hoplite.addMapSource
+import com.sksamuel.hoplite.env.Environment
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+@OptIn(ExperimentalHoplite::class)
+class HopliteContextResolverTest : FunSpec({
+
+  // Before the fix this returned `Runtime.getRuntime().availableProcessors()`, so the value of
+  // the placeholder was the CPU count of the host running the loader — completely unrelated to
+  // the Environment supplied to the config loader.
+  test("\${{ hoplite:env }} resolves to the configured environment name") {
+    data class Cfg(val region: String)
+
+    val cfg = ConfigLoaderBuilder.newBuilderWithoutPropertySources()
+      .withEnvironment(Environment.prod)
+      .addMapSource(mapOf("region" to "deploy-\${{ hoplite:env }}"))
+      .build()
+      .loadConfigOrThrow<Cfg>()
+
+    cfg.region shouldBe "deploy-prod"
+  }
+
+  test("\${{ hoplite:environment :- default }} falls back when no environment is configured") {
+    data class Cfg(val region: String)
+
+    val cfg = ConfigLoaderBuilder.newBuilderWithoutPropertySources()
+      .addMapSource(mapOf("region" to "deploy-\${{ hoplite:environment :- local }}"))
+      .build()
+      .loadConfigOrThrow<Cfg>()
+
+    cfg.region shouldBe "deploy-local"
+  }
+})


### PR DESCRIPTION
## Summary
\`HopliteContextResolver.lookup("env")\` was returning \`Runtime.getRuntime().availableProcessors().toString()\` — the number of CPU cores on the host. The doc comment on the resolver explicitly says it should return the Environment provided to the config loader (\`prod\`, \`dev\`, \`staging\`, …), and the rest of the framework already exposes that via \`DecoderContext.environment\`.

So a config like \`region: deploy-\${{ hoplite:env }}\` ran with \`Environment.prod\` was producing values like \`deploy-12\`. Loud bug, easy fix.

- Return \`context.environment?.name\` for both \`env\` and \`environment\` paths — the doc comment shows both forms in its example.
- When no environment is configured, return \`null\` so the resolver's \`:-default\` fallback path kicks in (matches the documented "Defaults can also be applied" behaviour).
- Drive-by: fix the \`"Uknown"\` typo in the failure message.

## Test plan
- [x] New \`HopliteContextResolverTest\` covers the happy path with an explicit \`Environment.prod\`, plus the \`:-default\` fallback path when no environment is set.
- [x] Full \`:hoplite-core:test\` suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)