### PR TITLE
Fix env-var list elements coming out in HashMap iteration order

### DIFF
--- a/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/sources/EnvironmentVariablesPropertySource.kt
+++ b/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/sources/EnvironmentVariablesPropertySource.kt
@@ -28,8 +28,12 @@ class EnvironmentVariablesPropertySource(
 
     return map.toNode("env", DELIMITER).transform { node ->
       if (node is MapNode && node.map.isNotEmpty() && node.map.keys.all { it.toIntOrNull() != null }) {
-        // all they map keys are ints, so lets transform the MapNode into an ArrayNode
-        ArrayNode(node.map.values.toList(), node.pos, node.path, node.meta, node.delimiter, node.sourceKey)
+        // All the map keys are integer index strings, so transform the MapNode into an ArrayNode.
+        // Sort by the integer value of the key — the upstream tree is backed by a HashMap, so
+        // iteration order is not tied to the index order and the list would otherwise come out
+        // shuffled.
+        val ordered = node.map.entries.sortedBy { it.key.toInt() }.map { it.value }
+        ArrayNode(ordered, node.pos, node.path, node.meta, node.delimiter, node.sourceKey)
       } else {
         node
       }

--- a/hoplite-core/src/test/kotlin/com/sksamuel/hoplite/EnvVarListOrderingTest.kt
+++ b/hoplite-core/src/test/kotlin/com/sksamuel/hoplite/EnvVarListOrderingTest.kt
@@ -1,0 +1,29 @@
+package com.sksamuel.hoplite
+
+import com.sksamuel.hoplite.sources.EnvironmentVariablesPropertySource
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+class EnvVarListOrderingTest : FunSpec({
+
+  // EnvironmentVariablesPropertySource builds a MapNode keyed on the integer index strings, then
+  // converts to an ArrayNode by taking `node.map.values.toList()`. The intermediate map is a
+  // HashMap (via hashMapOf()), so for a long-enough list the values come out in HashMap iteration
+  // order — which is not the integer-index order. The list ends up correctly sized but with the
+  // elements shuffled.
+  test("list elements should appear in integer-index order regardless of env iteration order") {
+    data class Cfg(val items: List<String>)
+
+    // 16 items is enough to push HashMap into a non-trivial bucket layout for Java 17+'s default
+    // HashMap (initial capacity 16). The reverse-insertion order makes the ordering bug surface
+    // even with implementations that happen to be insertion-order-stable for small maps.
+    val env = (0..15).reversed().associate { "ITEMS_$it" to "v$it" }
+
+    val cfg = ConfigLoaderBuilder.defaultWithoutPropertySources()
+      .addPropertySource(EnvironmentVariablesPropertySource(environmentVariableMap = { env }))
+      .build()
+      .loadConfigOrThrow<Cfg>()
+
+    cfg.items shouldBe (0..15).map { "v$it" }
+  }
+})


### PR DESCRIPTION
## Summary
\`EnvironmentVariablesPropertySource\` converts a \`MapNode\` whose keys are all integer strings into an \`ArrayNode\` via \`node.map.values.toList()\`. The intermediate \`Element\` tree in \`parsers/loadProps.kt\` uses \`hashMapOf()\` (a \`HashMap\`), so the values come out in HashMap iteration order — not the integer-index order.

For lists with more than a handful of items the elements end up silently shuffled. New test reproduces this with 16 items: \`ITEMS_0..ITEMS_15\` was decoding into \`[v11, v12, v13, v14, v15, v0, v1, ..., v10]\` — same set, wrong order.

## Fix
Sort by the integer value of the key when materialising the \`ArrayNode\`.

## Test plan
- [x] New \`EnvVarListOrderingTest\` fails before the fix, passes after
- [x] Full \`:hoplite-core:test\` suite still passes (the existing happy-path env list test uses a 3-element \`mapOf(...)\` which happened to iterate in insertion order — the new test forces the bug to surface)

🤖 Generated with [Claude Code](https://claude.com/claude-code)