### PR TITLE
Stop ConfigSource.fromPaths/fromClasspathResources leaking streams

### DIFF
--- a/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/ConfigSource.kt
+++ b/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/ConfigSource.kt
@@ -106,19 +106,21 @@ abstract class ConfigSource {
       classpathResourceLoader: ClasspathResourceLoader = Companion::class.java.toClasspathResourceLoader()
     ): ConfigResult<List<ConfigSource>> {
       return resources.map { resource ->
-        classpathResourceLoader.getResourceAsStream(resource)
-          ?.let { ClasspathSource(resource, classpathResourceLoader).valid() }
-          ?: ConfigFailure.UnknownSource(resource).invalid()
+        // Probe for existence; close immediately so we don't leak a stream that the actual load
+        // (later, via ConfigFilePropertySource) will reopen.
+        val exists = classpathResourceLoader.getResourceAsStream(resource)?.use { true } ?: false
+        if (exists) ClasspathSource(resource, classpathResourceLoader).valid()
+        else ConfigFailure.UnknownSource(resource).invalid()
       }.sequence()
         .mapInvalid { ConfigFailure.MultipleFailures(it) }
     }
 
     fun fromPaths(paths: List<Path>): ConfigResult<List<ConfigSource>> {
       return paths.map { path ->
-        runCatching { Files.newInputStream(path) }.fold(
-          { PathSource(path).valid() },
-          { ConfigFailure.UnknownSource(path.toString()).invalid() }
-        )
+        // Don't open a stream just to check existence — Files.exists is cheaper and doesn't leak
+        // a file handle (the previous implementation opened a stream and discarded it).
+        if (path.exists()) PathSource(path).valid()
+        else ConfigFailure.UnknownSource(path.toString()).invalid()
       }.sequence()
         .mapInvalid { ConfigFailure.MultipleFailures(it) }
     }

--- a/hoplite-core/src/test/kotlin/com/sksamuel/hoplite/ConfigSourceFromPathsTest.kt
+++ b/hoplite-core/src/test/kotlin/com/sksamuel/hoplite/ConfigSourceFromPathsTest.kt
@@ -1,0 +1,42 @@
+package com.sksamuel.hoplite
+
+import com.sksamuel.hoplite.fp.Validated
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import java.nio.file.Files
+import java.nio.file.Paths
+import kotlin.io.path.deleteIfExists
+
+class ConfigSourceFromPathsTest : FunSpec({
+
+  test("fromPaths returns Valid for existing paths") {
+    val tempFile = Files.createTempFile("hoplite-cs-test", ".yml")
+    try {
+      Files.writeString(tempFile, "x: 1")
+      val result = ConfigSource.fromPaths(listOf(tempFile))
+      result.shouldBeInstanceOf<Validated.Valid<List<ConfigSource>>>()
+      result.value.size shouldBe 1
+    } finally {
+      tempFile.deleteIfExists()
+    }
+  }
+
+  test("fromPaths returns Invalid for missing paths") {
+    val missing = Paths.get("/nonexistent/hoplite-cs-test-${System.nanoTime()}.yml")
+    val result = ConfigSource.fromPaths(listOf(missing))
+    result.shouldBeInstanceOf<Validated.Invalid<*>>()
+  }
+
+  test("fromClasspathResources returns Valid for existing resources") {
+    // basic.props is a fixture under hoplite-core test resources
+    val result = ConfigSource.fromClasspathResources(listOf("/basic.props"))
+    result.shouldBeInstanceOf<Validated.Valid<List<ConfigSource>>>()
+    result.value.size shouldBe 1
+  }
+
+  test("fromClasspathResources returns Invalid for missing resources") {
+    val result = ConfigSource.fromClasspathResources(listOf("/no-such-resource-${System.nanoTime()}.yml"))
+    result.shouldBeInstanceOf<Validated.Invalid<*>>()
+  }
+})


### PR DESCRIPTION
## Summary
\`ConfigSource.fromPaths\` opens \`Files.newInputStream(path)\` for each path *just to test existence*, then discards the stream — one leaked file handle per path. \`ConfigSource.fromClasspathResources\` has the analogous leak via \`getResourceAsStream(...)\` without closing the probe stream.

The actual load happens later through \`ConfigFilePropertySource\`, which opens and closes its own stream. The probe streams here were always pure waste.

## Fix
- \`fromPaths\`: replace the open-and-discard with \`Files.exists()\` (the file already imports \`kotlin.io.path.exists\` for \`PathSource.open\`).
- \`fromClasspathResources\`: keep the existence probe but wrap it in \`.use { }\` so the stream is closed immediately.

## Test plan
- [x] New \`ConfigSourceFromPathsTest\` covers happy path + missing-path / missing-resource for both methods. Behaviour is unchanged.
- [x] \`:hoplite-core:test\` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)