### PR TITLE
Close input streams in UserSettings and XdgConfig sources

### DIFF
--- a/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/sources/UserSettingsPropertySource.kt
+++ b/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/sources/UserSettingsPropertySource.kt
@@ -33,9 +33,8 @@ object UserSettingsPropertySource : PropertySource {
     }
     return if (ext == null) Undefined.valid() else {
       val path = path(ext)
-      val input = path.inputStream()
-      context.parsers.locate(ext).map {
-        it.load(input, path.toString())
+      context.parsers.locate(ext).map { parser ->
+        path.inputStream().use { input -> parser.load(input, path.toString()) }
       }
     }
   }

--- a/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/sources/XdgConfigPropertySource.kt
+++ b/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/sources/XdgConfigPropertySource.kt
@@ -36,9 +36,8 @@ object XdgConfigPropertySource : PropertySource {
       path(ext).takeIf { it?.exists() ?: false }
     }
     return if (path == null) Undefined.valid() else {
-      val input = path.inputStream()
-      context.parsers.locate(path.extension).map {
-        it.load(input, path.toString())
+      context.parsers.locate(path.extension).map { parser ->
+        path.inputStream().use { input -> parser.load(input, path.toString()) }
       }
     }
   }

--- a/hoplite-core/src/test/kotlin/com/sksamuel/hoplite/sources/UserSettingsPropertySourceTest.kt
+++ b/hoplite-core/src/test/kotlin/com/sksamuel/hoplite/sources/UserSettingsPropertySourceTest.kt
@@ -1,0 +1,50 @@
+package com.sksamuel.hoplite.sources
+
+import com.sksamuel.hoplite.MapNode
+import com.sksamuel.hoplite.Node
+import com.sksamuel.hoplite.Pos
+import com.sksamuel.hoplite.PropertySourceContext
+import com.sksamuel.hoplite.decoder.DotPath
+import com.sksamuel.hoplite.parsers.DefaultParserRegistry
+import com.sksamuel.hoplite.parsers.Parser
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.engine.spec.tempdir
+import io.kotest.matchers.shouldBe
+import java.io.IOException
+import java.io.InputStream
+import java.util.concurrent.atomic.AtomicReference
+
+class UserSettingsPropertySourceTest : FunSpec({
+
+  test("closes the input stream after the parser has consumed it (#533)") {
+    val home = tempdir()
+    val userConfig = home.resolve(".userconfig.testext")
+    userConfig.writeText("ignored")
+
+    val captured = AtomicReference<InputStream>()
+    val parser = object : Parser {
+      override fun load(input: InputStream, source: String): Node {
+        captured.set(input)
+        input.readBytes()
+        return MapNode(emptyMap(), Pos.NoPos, DotPath.root)
+      }
+
+      override fun defaultFileExtensions(): List<String> = listOf("testext")
+    }
+    val context = PropertySourceContext(DefaultParserRegistry(mapOf("testext" to parser)))
+
+    val previousHome = System.getProperty("user.home")
+    try {
+      System.setProperty("user.home", home.absolutePath)
+      UserSettingsPropertySource.node(context)
+    } finally {
+      if (previousHome == null) System.clearProperty("user.home") else System.setProperty("user.home", previousHome)
+    }
+
+    // After node() returns, the stream the parser saw must be closed.
+    // Reading from a closed FileInputStream / ChannelInputStream throws IOException.
+    val readAfter = runCatching { captured.get().read() }
+    readAfter.isFailure shouldBe true
+    (readAfter.exceptionOrNull() is IOException) shouldBe true
+  }
+})


### PR DESCRIPTION
## Summary
\`UserSettingsPropertySource\` and \`XdgConfigPropertySource\` open the user's config file via \`path.inputStream()\` and hand it off to \`parser.load(...)\` without ever closing it. Each \`loadConfig\` call leaks one file descriptor when the user/xdg config file exists.

## Fix
Wrap the input stream in \`.use { }\` so it is closed on both the happy path and the parser exception path.

## Test plan
- [x] \`:hoplite-core:test\` passes (existing user/xdg behaviour is unchanged — the stream was always read fully before the leak).

🤖 Generated with [Claude Code](https://claude.com/claude-code)