### PR TITLE
Mark LinkedHashMap entries as used so strict() doesn't flag them

### DIFF
--- a/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/decoder/LinkedHashMapDecoder.kt
+++ b/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/decoder/LinkedHashMapDecoder.kt
@@ -37,6 +37,9 @@ class LinkedHashMapDecoder : NullHandlingDecoder<LinkedHashMap<*, *>> {
       return node.denormalize().map.entries.map { (k, v) ->
         kdecoder.decode(StringNode(k, node.pos, node.path, emptyMap()), kType, context).flatMap { kk ->
           vdecoder.decode(v, vType, context).map { vv ->
+            // Mark each entry as used so strict mode does not report them as unused — matches
+            // what MapDecoder does for the regular Map<K, V> case.
+            context.usedPaths.add(v.path)
             kk to vv
           }
         }

--- a/hoplite-core/src/test/kotlin/com/sksamuel/hoplite/decoder/LinkedHashMapStrictModeTest.kt
+++ b/hoplite-core/src/test/kotlin/com/sksamuel/hoplite/decoder/LinkedHashMapStrictModeTest.kt
@@ -1,0 +1,25 @@
+package com.sksamuel.hoplite.decoder
+
+import com.sksamuel.hoplite.ConfigLoaderBuilder
+import com.sksamuel.hoplite.addMapSource
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+class LinkedHashMapStrictModeTest : FunSpec({
+
+  // MapDecoder explicitly calls context.usedPaths.add(v.path) for each value, so strict mode
+  // doesn't flag the child entries as unused. LinkedHashMapDecoder forgot to do the same — so
+  // strict() incorrectly reported every entry of a LinkedHashMap field as unused, even though
+  // every entry was decoded into the resulting value.
+  test("strict mode should accept all entries of a LinkedHashMap") {
+    data class Cfg(val m: LinkedHashMap<String, String>)
+
+    val cfg = ConfigLoaderBuilder.defaultWithoutPropertySources()
+      .addMapSource(mapOf("m.a" to "1", "m.b" to "2", "m.c" to "3"))
+      .strict()
+      .build()
+      .loadConfigOrThrow<Cfg>()
+
+    cfg.m shouldBe linkedMapOf("a" to "1", "b" to "2", "c" to "3")
+  }
+})


### PR DESCRIPTION
## Summary
\`LinkedHashMapDecoder\` was missing the \`context.usedPaths.add(v.path)\` call that \`MapDecoder\` makes for each entry. Strict mode therefore reported every entry of a \`LinkedHashMap\` field as unused, even though every entry was decoded into the resulting value:

\`\`\`
Config value 'm.a' at (map) was unused
Config value 'm.b' at (map) was unused
Config value 'm.c' at (map) was unused
\`\`\`

Add the same mark so the two decoders behave identically.

## Test plan
- [x] New \`LinkedHashMapStrictModeTest\` exercises \`strict()\` against a \`LinkedHashMap<String, String>\` field. Fails before, passes after.
- [x] \`:hoplite-core:test\` and \`:hoplite-yaml:test\` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)