### PR TITLE
Mark vavr Map entries as used so strict() doesn't flag them

### DIFF
--- a/hoplite-vavr/src/main/kotlin/com/sksamuel/hoplite/decoder/vavr/MapDecoder.kt
+++ b/hoplite-vavr/src/main/kotlin/com/sksamuel/hoplite/decoder/vavr/MapDecoder.kt
@@ -35,6 +35,9 @@ class MapDecoder : NullHandlingDecoder<Map<*, *>> {
       node.denormalize().map.entries.map { (k, v) ->
         kdecoder.decode(StringNode(k, node.pos, node.path, emptyMap()), kType, context).flatMap { kk ->
           vdecoder.decode(v, vType, context).map { vv ->
+            // Mark each entry as used so strict mode does not report them as unused — matches
+            // what the core MapDecoder does for the regular Map<K, V> case.
+            context.usedPaths.add(v.path)
             kk to vv
           }
         }

--- a/hoplite-vavr/src/test/kotlin/com/sksamuel/hoplite/decoder/vavr/MapDecoderTest.kt
+++ b/hoplite-vavr/src/test/kotlin/com/sksamuel/hoplite/decoder/vavr/MapDecoderTest.kt
@@ -1,6 +1,8 @@
 package com.sksamuel.hoplite.decoder.vavr
 
 import com.sksamuel.hoplite.ConfigLoader
+import com.sksamuel.hoplite.ConfigLoaderBuilder
+import com.sksamuel.hoplite.addMapSource
 import com.sksamuel.hoplite.sources.EnvironmentVariablesPropertySource
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
@@ -32,4 +34,15 @@ class MapDecoderTest : FunSpec({
     } shouldBe Test(linkedHashMap("key1" to "test1", "key2" to "test2", "key-3" to "test3", "Key4" to "test4"))
   }
 
+  // Vavr MapDecoder used to forget context.usedPaths.add(v.path), so strict mode rejected every
+  // entry of a vavr Map field as unused even though every entry was decoded.
+  test("strict mode should accept all entries of a vavr Map") {
+    val config = ConfigLoaderBuilder.defaultWithoutPropertySources()
+      .addMapSource(mapOf("map.a" to "1", "map.b" to "2", "map.c" to "3"))
+      .strict()
+      .build()
+      .loadConfigOrThrow<Test>()
+
+    config shouldBe Test(linkedHashMap("a" to "1", "b" to "2", "c" to "3"))
+  }
 })


### PR DESCRIPTION
## Summary
The vavr \`MapDecoder\` mirrored the (broken) state of \`LinkedHashMapDecoder\`: it forgot the \`context.usedPaths.add(v.path)\` call that the core \`MapDecoder\` makes. Strict mode therefore reported every entry of an \`io.vavr.Map\` field as unused even though every entry was decoded into the resulting value.

Sister PR to #534 for the core LinkedHashMapDecoder.

## Test plan
- [x] New test in \`MapDecoderTest\` exercises \`strict()\` against a vavr \`Map<String, String>\` field.
- [x] \`:hoplite-vavr:test\` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)