### PR TITLE
Recognise Null / NULL / ~ as YAML null literals

### DIFF
--- a/hoplite-yaml/src/main/kotlin/com/sksamuel/hoplite/yaml/YamlParser.kt
+++ b/hoplite-yaml/src/main/kotlin/com/sksamuel/hoplite/yaml/YamlParser.kt
@@ -97,7 +97,10 @@ object TokenProduction {
       //    { Y, true, Yes, ON  }    : Boolean true
       //    { n, FALSE, No, off }    : Boolean false
       is ScalarEvent -> {
-        val node = if (event.value == "null" && event.scalarStyle == DumperOptions.ScalarStyle.PLAIN)
+        // YAML 1.1/1.2 PLAIN style allows `null`, `Null`, `NULL`, and `~` as null. The previous
+        // implementation only recognised the literal lowercase `null`; the others produced
+        // StringNodes containing the literal text.
+        val node = if (event.scalarStyle == DumperOptions.ScalarStyle.PLAIN && isYamlNullLiteral(event.value))
           NullNode(event.startMark.toPos(source), path, emptyMap())
         else
           StringNode(event.value, event.startMark.toPos(source), path, emptyMap())
@@ -174,3 +177,9 @@ object SequenceProduction {
 }
 
 fun Mark.toPos(source: String): Pos = Pos.LineColPos(line, column, source)
+
+// YAML 1.1/1.2 PLAIN-scalar null literals.
+private fun isYamlNullLiteral(value: String): Boolean = when (value) {
+  "null", "Null", "NULL", "~" -> true
+  else -> false
+}

--- a/hoplite-yaml/src/test/kotlin/com/sksamuel/hoplite/yaml/NullVariantsTest.kt
+++ b/hoplite-yaml/src/test/kotlin/com/sksamuel/hoplite/yaml/NullVariantsTest.kt
@@ -1,0 +1,24 @@
+package com.sksamuel.hoplite.yaml
+
+import com.sksamuel.hoplite.ConfigLoader
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+class NullVariantsTest : FunSpec({
+
+  // YAML 1.1/1.2 PLAIN style allows `null`, `Null`, `NULL`, and `~` as null. The hoplite YAML
+  // parser only recognised the lowercase literal `null`; the others were producing StringNodes
+  // containing the literal text, so a nullable String? field surprisingly came out non-null.
+  test("YAML null variants should all decode to null") {
+    data class Cfg(
+      val a: String?,
+      val b: String?,
+      val c: String?,
+      val d: String?,
+    )
+
+    val cfg = ConfigLoader().loadConfigOrThrow<Cfg>("/test_null_variants.yml")
+
+    cfg shouldBe Cfg(a = null, b = null, c = null, d = null)
+  }
+})

--- a/hoplite-yaml/src/test/resources/test_null_variants.yml
+++ b/hoplite-yaml/src/test/resources/test_null_variants.yml
@@ -1,0 +1,4 @@
+a: null
+b: Null
+c: NULL
+d: ~


### PR DESCRIPTION
## Summary
The YAML parser only treated the lowercase string \`null\` in PLAIN style as a \`NullNode\`. YAML 1.1 and 1.2 also recognise \`Null\`, \`NULL\`, and \`~\` as null in plain style — those previously came through as \`StringNode\`s containing the literal text. A \`val a: String?\` field with \`a: Null\` in the YAML ended up holding the string \`"Null"\` instead of being null.

## Test plan
- [x] New \`NullVariantsTest\` covers \`null\` / \`Null\` / \`NULL\` / \`~\` in a single fixture and asserts all four decode to \`null\`. Fails before, passes after.
- [x] \`:hoplite-yaml:test\` passes (existing \`null\` handling is unchanged; the four cases above now also work).

🤖 Generated with [Claude Code](https://claude.com/claude-code)