### PR TITLE
Stop SystemPropertyContextResolver crashing on empty-key placeholders

### DIFF
--- a/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/resolver/context/SystemPropertyContextResolver.kt
+++ b/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/resolver/context/SystemPropertyContextResolver.kt
@@ -16,7 +16,11 @@ object SystemPropertyContextResolver : ContextResolver() {
   override val default = true
 
   override fun lookup(path: String, node: StringNode, root: Node, context: DecoderContext): ConfigResult<String?> {
-    return System.getProperty(path).valid()
+    // System.getProperty throws IllegalArgumentException on an empty key, which can happen for a
+    // placeholder like `${{ sysprop: }}` or `${{ sysprop:   }}`. Treat an empty key as "not set"
+    // so the resolver's :- fallback path engages or an unresolved-substitution failure is reported,
+    // rather than crashing the loader.
+    return if (path.isEmpty()) null.valid() else System.getProperty(path).valid()
   }
 
 }

--- a/hoplite-core/src/test/kotlin/com/sksamuel/hoplite/resolver/context/SystemPropertyContextResolverEmptyKeyTest.kt
+++ b/hoplite-core/src/test/kotlin/com/sksamuel/hoplite/resolver/context/SystemPropertyContextResolverEmptyKeyTest.kt
@@ -1,0 +1,36 @@
+package com.sksamuel.hoplite.resolver.context
+
+import com.sksamuel.hoplite.ConfigException
+import com.sksamuel.hoplite.ConfigLoaderBuilder
+import com.sksamuel.hoplite.ExperimentalHoplite
+import com.sksamuel.hoplite.addMapSource
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+@OptIn(ExperimentalHoplite::class)
+class SystemPropertyContextResolverEmptyKeyTest : FunSpec({
+
+  // System.getProperty(key) throws IllegalArgumentException when key is empty. The resolver
+  // previously called it without guarding, so a placeholder like `${{ sysprop:  }}` (or one whose
+  // key trimmed down to empty) crashed the loader instead of producing a clean failure.
+  test("\${{ sysprop:  }} should not crash and is reported as unresolved") {
+    data class Cfg(val a: String)
+    shouldThrow<ConfigException> {
+      ConfigLoaderBuilder.newBuilderWithoutPropertySources()
+        .addMapSource(mapOf("a" to "\${{ sysprop:  }}"))
+        .build()
+        .loadConfigOrThrow<Cfg>()
+    }
+  }
+
+  test("\${{ sysprop:somekey :- fallback }} for a missing property uses the fallback") {
+    System.clearProperty("hoplite.unset.test.key")
+    data class Cfg(val a: String)
+    val cfg = ConfigLoaderBuilder.newBuilderWithoutPropertySources()
+      .addMapSource(mapOf("a" to "\${{ sysprop:hoplite.unset.test.key :- fallback }}"))
+      .build()
+      .loadConfigOrThrow<Cfg>()
+    cfg.a shouldBe "fallback"
+  }
+})


### PR DESCRIPTION
## Summary
\`System.getProperty(key)\` throws \`IllegalArgumentException\` when \`key\` is empty. \`SystemPropertyContextResolver.lookup\` called it without guarding, so a placeholder like \`\${{ sysprop:  }}\` (one whose inner trims down to empty) crashed the loader instead of producing a clean failure.

Same family of bug as #522 in the legacy \`EnvOrSystemPropertyPreprocessor\`. Short-circuit to \`null\` for an empty key so the regular resolver pipeline either uses the \`:-\` fallback or reports an unresolved-substitution failure.

## Test plan
- [x] New test verifies \`\${{ sysprop:  }}\` doesn't crash and is reported as unresolved (was: \`IllegalArgumentException: key can't be empty\`).
- [x] Sanity test for the regular fallback path still passes.
- [x] \`:hoplite-core:test\` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)