### PR TITLE
Let arrow/vavr OptionDecoder accept MapNode and ArrayNode

### DIFF
--- a/hoplite-arrow/src/main/kotlin/com/sksamuel/hoplite/decoder/arrow/OptionDecoder.kt
+++ b/hoplite-arrow/src/main/kotlin/com/sksamuel/hoplite/decoder/arrow/OptionDecoder.kt
@@ -37,8 +37,11 @@ class OptionDecoder : Decoder<Option<*>> {
       when (node) {
         is Undefined -> None.valid()
         is NullNode -> None.valid()
-        is StringNode, is LongNode, is DoubleNode, is BooleanNode -> decode(node, decoder)
-        else -> ConfigFailure.DecodeError(node, type).invalid()
+        // Defer to the inner decoder for any other node type. Previously this only enumerated the
+        // primitive node types, so `Option<MyConfig>` (a data class — MapNode) and
+        // `Option<List<X>>` (ArrayNode) would fail with DecodeError even though the inner decoders
+        // know exactly how to handle them.
+        else -> decode(node, decoder)
       }
     }
   }

--- a/hoplite-arrow/src/test/kotlin/com/sksamuel/hoplite/arrow/OptionTest.kt
+++ b/hoplite-arrow/src/test/kotlin/com/sksamuel/hoplite/arrow/OptionTest.kt
@@ -4,6 +4,8 @@ import arrow.core.None
 import arrow.core.Option
 import arrow.core.Some
 import com.sksamuel.hoplite.ConfigLoader
+import com.sksamuel.hoplite.ConfigLoaderBuilder
+import com.sksamuel.hoplite.addMapSource
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import java.util.*
@@ -23,5 +25,31 @@ class OptionTest : FunSpec({
     foo.c shouldBe Some("hello")
     foo.d shouldBe Some(123L)
     foo.e shouldBe Some(UUID.fromString("383d27c5-d087-4d36-b4c4-6dd7defe088d"))
+  }
+
+  // OptionDecoder used to enumerate only the primitive node types (StringNode, LongNode, …),
+  // so Option<DataClass> and Option<List<X>> failed with DecodeError despite the inner decoders
+  // being perfectly capable. Defer to the inner decoder for non-null/undefined nodes.
+  test("Option<DataClass> decodes a present nested data class") {
+    data class Inner(val name: String, val count: Int)
+    data class Outer(val inner: Option<Inner>)
+
+    val cfg = ConfigLoaderBuilder.defaultWithoutPropertySources()
+      .addMapSource(mapOf("inner.name" to "rimmer", "inner.count" to "3"))
+      .build()
+      .loadConfigOrThrow<Outer>()
+
+    cfg.inner shouldBe Some(Inner("rimmer", 3))
+  }
+
+  test("Option<List<String>> decodes a present list") {
+    data class Outer(val xs: Option<List<String>>)
+
+    val cfg = ConfigLoaderBuilder.defaultWithoutPropertySources()
+      .addMapSource(mapOf("xs" to listOf("a", "b", "c")))
+      .build()
+      .loadConfigOrThrow<Outer>()
+
+    cfg.xs shouldBe Some(listOf("a", "b", "c"))
   }
 })

--- a/hoplite-vavr/src/main/kotlin/com/sksamuel/hoplite/decoder/vavr/OptionDecoder.kt
+++ b/hoplite-vavr/src/main/kotlin/com/sksamuel/hoplite/decoder/vavr/OptionDecoder.kt
@@ -26,8 +26,11 @@ class OptionDecoder : Decoder<Option<*>> {
       when (node) {
         is Undefined -> none<Option<*>>().valid()
         is NullNode -> none<Option<*>>().valid()
-        is StringNode, is LongNode, is DoubleNode, is BooleanNode -> decode(node, decoder)
-        else -> ConfigFailure.DecodeError(node, type).invalid()
+        // Defer to the inner decoder for any other node type. Previously this only enumerated the
+        // primitive node types, so `Option<MyConfig>` (a data class — MapNode) and
+        // `Option<List<X>>` (ArrayNode) would fail with DecodeError even though the inner decoders
+        // know exactly how to handle them.
+        else -> decode(node, decoder)
       }
     }
   }

--- a/hoplite-vavr/src/test/kotlin/com/sksamuel/hoplite/decoder/vavr/OptionDecoderTest.kt
+++ b/hoplite-vavr/src/test/kotlin/com/sksamuel/hoplite/decoder/vavr/OptionDecoderTest.kt
@@ -1,6 +1,8 @@
 package com.sksamuel.hoplite.decoder.vavr
 
 import com.sksamuel.hoplite.ConfigLoader
+import com.sksamuel.hoplite.ConfigLoaderBuilder
+import com.sksamuel.hoplite.addMapSource
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.vavr.control.Option
@@ -20,4 +22,29 @@ class OptionDecoderTest : FunSpec({
     config.c shouldBe some(123)
   }
 
+  // OptionDecoder used to enumerate only the primitive node types (StringNode, LongNode, …),
+  // so Option<DataClass> and Option<List<X>> failed with DecodeError despite the inner decoders
+  // being perfectly capable.
+  test("Option<DataClass> decodes a present nested data class") {
+    data class Inner(val name: String, val count: Int)
+    data class Outer(val inner: Option<Inner>)
+
+    val cfg = ConfigLoaderBuilder.defaultWithoutPropertySources()
+      .addMapSource(mapOf("inner.name" to "rimmer", "inner.count" to "3"))
+      .build()
+      .loadConfigOrThrow<Outer>()
+
+    cfg.inner shouldBe some(Inner("rimmer", 3))
+  }
+
+  test("Option<List<String>> decodes a present list") {
+    data class Outer(val xs: Option<List<String>>)
+
+    val cfg = ConfigLoaderBuilder.defaultWithoutPropertySources()
+      .addMapSource(mapOf("xs" to listOf("a", "b", "c")))
+      .build()
+      .loadConfigOrThrow<Outer>()
+
+    cfg.xs shouldBe some(listOf("a", "b", "c"))
+  }
 })


### PR DESCRIPTION
## Summary
Both \`OptionDecoder\`s (in \`hoplite-arrow\` and \`hoplite-vavr\`) enumerated only the primitive node types in their \`when\` block:

\`\`\`kotlin
is StringNode, is LongNode, is DoubleNode, is BooleanNode -> decode(node, decoder)
else -> ConfigFailure.DecodeError(node, type).invalid()
\`\`\`

So \`Option<MyConfig>\` (a data class — \`MapNode\`) and \`Option<List<X>>\` (\`ArrayNode\`) failed with \`DecodeError\` even though the inner decoders are perfectly capable of handling those nodes — the outer Option wrapper was rejecting them needlessly.

## Fix
Defer to the inner decoder for any node that isn't \`Undefined\` or \`NullNode\`. \`None\` still maps to the empty Option as before; only the "value is present" branch is broadened.

## Test plan
- [x] New tests for \`Option<DataClass>\` and \`Option<List<String>>\` in both arrow and vavr modules.
- [x] Existing primitive-Option tests still pass.
- [x] \`:hoplite-arrow:test\` and \`:hoplite-vavr:test\` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)