### PR TITLE
Stop ConfigSource.fromResourcesOrFiles leaking the probe stream

### DIFF
--- a/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/ConfigSource.kt
+++ b/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/ConfigSource.kt
@@ -80,9 +80,11 @@ abstract class ConfigSource {
       return if (path.exists()) {
         PathSource(path).valid()
       } else {
-        classpathResourceLoader.getResourceAsStream(resourceOrFile)
-          ?.let { ClasspathSource(resourceOrFile, classpathResourceLoader).valid() }
-          ?: ConfigFailure.UnknownSource(resourceOrFile).invalid()
+        // Probe for existence; close immediately so we don't leak a stream that the actual load
+        // (later, via ConfigFilePropertySource) will reopen.
+        val exists = classpathResourceLoader.getResourceAsStream(resourceOrFile)?.use { true } ?: false
+        if (exists) ClasspathSource(resourceOrFile, classpathResourceLoader).valid()
+        else ConfigFailure.UnknownSource(resourceOrFile).invalid()
       }
     }
 


### PR DESCRIPTION
## Summary
Sister fix to #532. The singular \`fromResourcesOrFiles(String, ...)\` had the same stream-leak bug as \`fromClasspathResources\` fixed in #532: it opened a classpath stream just to test for existence and discarded it without closing. The plural \`fromResourcesOrFiles(List<String>, ...)\` calls the singular form, so it leaked too.

## Fix
Wrap the probe stream in \`.use { }\` so it's closed immediately. The actual config load happens later via \`ConfigFilePropertySource\`, which opens its own stream and closes it correctly.

## Test plan
- [x] \`:hoplite-core:test\` passes; behaviour is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)