### PR TITLE
Close the input stream in InputStreamPropertySource

### DIFF
--- a/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/sources/InputStreamPropertySource.kt
+++ b/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/sources/InputStreamPropertySource.kt
@@ -26,8 +26,11 @@ class InputStreamPropertySource(
   override fun source(): String = source
 
   override fun node(context: PropertySourceContext): ConfigResult<Node> {
-    return context.parsers.locate(ext).map {
-      it.load(input, source)
+    // Close the stream when we're done with it. Matches ConfigFilePropertySource and the
+    // user/xdg sources — every other PropertySource that opens a stream closes it. The previous
+    // implementation handed the input stream to the parser and never closed it.
+    return context.parsers.locate(ext).map { parser ->
+      input.use { parser.load(it, source) }
     }
   }
 }


### PR DESCRIPTION
## Summary
\`InputStreamPropertySource\` handed the user-provided \`InputStream\` to the parser and never closed it. Every other \`PropertySource\` that opens a stream closes it (\`ConfigFilePropertySource\` via \`input.use { }\`, \`UserSettingsPropertySource\`/\`XdgConfigPropertySource\` after #533) — this one was the odd one out.

## Fix
Wrap the parser invocation in \`input.use { ... }\` so the stream is closed on both the happy path and the parser exception path.

## Test plan
- [x] \`:hoplite-core:test\` passes; behaviour is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)