### PR TITLE
Catch exceptions in hoplite-javax security decoders

### DIFF
--- a/hoplite-javax/src/main/kotlin/com/sksamuel/hoplite/decoder/javax/security.kt
+++ b/hoplite-javax/src/main/kotlin/com/sksamuel/hoplite/decoder/javax/security.kt
@@ -15,7 +15,13 @@ import kotlin.reflect.KType
 
 fun <T> viaString(node: Node, type: KType, f: (String) -> T): ConfigResult<T> {
   return when (node) {
-    is StringNode -> f(node.value).valid()
+    // The constructors of KerberosPrincipal / X500Principal throw IllegalArgumentException for
+    // bad input; without runCatching the exception propagates uncaught. Surface it as a clean
+    // ConfigFailure instead.
+    is StringNode -> runCatching { f(node.value) }.fold(
+      { it.valid() },
+      { ConfigFailure.DecodeError(node, type).invalid() }
+    )
     else -> ConfigFailure.DecodeError(node, type).invalid()
   }
 }

--- a/hoplite-javax/src/test/kotlin/com/sksamuel/hoplite/decoder/javax/SecurityDecodersTest.kt
+++ b/hoplite-javax/src/test/kotlin/com/sksamuel/hoplite/decoder/javax/SecurityDecodersTest.kt
@@ -1,0 +1,48 @@
+package com.sksamuel.hoplite.decoder.javax
+
+import com.sksamuel.hoplite.ConfigException
+import com.sksamuel.hoplite.ConfigLoaderBuilder
+import com.sksamuel.hoplite.addMapSource
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import javax.security.auth.kerberos.KerberosPrincipal
+import javax.security.auth.x500.X500Principal
+
+class SecurityDecodersTest : FunSpec({
+
+  test("KerberosPrincipal decodes a valid principal") {
+    data class Cfg(val p: KerberosPrincipal)
+    val cfg = ConfigLoaderBuilder.defaultWithoutPropertySources()
+      .addDecoder(KerberosPrincipalDecoder())
+      .addMapSource(mapOf("p" to "alice@EXAMPLE.COM"))
+      .build()
+      .loadConfigOrThrow<Cfg>()
+    cfg.p shouldBe KerberosPrincipal("alice@EXAMPLE.COM")
+  }
+
+  // viaString used to call f(node.value) directly. KerberosPrincipal's constructor throws
+  // IllegalArgumentException on a bad name (e.g. missing realm), so the exception propagated
+  // uncaught and crashed the loader instead of producing a clean ConfigFailure.
+  test("KerberosPrincipal with an invalid name produces a ConfigException, not a raw exception") {
+    data class Cfg(val p: KerberosPrincipal)
+    shouldThrow<ConfigException> {
+      ConfigLoaderBuilder.defaultWithoutPropertySources()
+        .addDecoder(KerberosPrincipalDecoder())
+        .addMapSource(mapOf("p" to ""))
+        .build()
+        .loadConfigOrThrow<Cfg>()
+    }
+  }
+
+  test("X500Principal with an invalid DN produces a ConfigException, not a raw exception") {
+    data class Cfg(val p: X500Principal)
+    shouldThrow<ConfigException> {
+      ConfigLoaderBuilder.defaultWithoutPropertySources()
+        .addDecoder(X500PrincipalDecoder())
+        .addMapSource(mapOf("p" to "this is not a distinguished name"))
+        .build()
+        .loadConfigOrThrow<Cfg>()
+    }
+  }
+})


### PR DESCRIPTION
## Summary
The \`viaString\` helper in \`hoplite-javax\` called \`f(node.value)\` directly without \`runCatching\`. \`KerberosPrincipal\` and \`X500Principal\` both throw \`IllegalArgumentException\` on bad input — \`KerberosPrincipal\` rejects empty / realm-less names, \`X500Principal\` rejects strings that aren't valid RFC 1779/2253 distinguished names — so invalid input crashed the config loader with a raw exception instead of producing a clean \`ConfigFailure\`.

Same pattern as the \`RegexDecoder\`/\`BooleanArrayDecoder\` fixes in #520. Wrap in \`runCatching\` and surface failures as \`DecodeError\`.

## Test plan
- [x] New \`SecurityDecodersTest\` covers happy path for \`KerberosPrincipal\` and the failure path for \`KerberosPrincipal\` (empty name) and \`X500Principal\` (invalid DN). Both failure tests would have crashed with \`IllegalArgumentException\` before; now they produce \`ConfigException\` like every other decoder.
- [x] \`:hoplite-javax:test\` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)