### PR TITLE
Allow negative endpoints in IntRange / LongRange decoders

### DIFF
--- a/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/decoder/ranges.kt
+++ b/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/decoder/ranges.kt
@@ -45,7 +45,9 @@ class CharRangeDecoder : NullHandlingDecoder<CharRange> {
 
 object RangeDecoders {
 
-  private val numericRangePattern = "(\\d+)\\.\\.(\\d+)".toRegex()
+  // The previous pattern was `(\d+)\.\.(\d+)`, which rejected negative numbers — `IntRange(-5, 5)`
+  // is a perfectly valid Kotlin range but `-5..5` could not be decoded. Allow an optional `-`.
+  private val numericRangePattern = "(-?\\d+)\\.\\.(-?\\d+)".toRegex()
 
   private val textRangePattern = "(\\w+)\\.\\.(\\w+)".toRegex()
 

--- a/hoplite-core/src/test/kotlin/com/sksamuel/hoplite/decoder/RangeDecodersTest.kt
+++ b/hoplite-core/src/test/kotlin/com/sksamuel/hoplite/decoder/RangeDecodersTest.kt
@@ -1,0 +1,47 @@
+package com.sksamuel.hoplite.decoder
+
+import com.sksamuel.hoplite.ConfigLoaderBuilder
+import com.sksamuel.hoplite.addMapSource
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+class RangeDecodersTest : FunSpec({
+
+  // The previous regex required digits only, so `-5..5` failed to decode even though IntRange and
+  // LongRange both happily represent ranges with negative endpoints.
+  test("IntRange should accept negative endpoints") {
+    data class Cfg(val r: IntRange)
+    val cfg = ConfigLoaderBuilder.defaultWithoutPropertySources()
+      .addMapSource(mapOf("r" to "-5..5"))
+      .build()
+      .loadConfigOrThrow<Cfg>()
+    cfg.r shouldBe IntRange(-5, 5)
+  }
+
+  test("IntRange should accept both endpoints negative") {
+    data class Cfg(val r: IntRange)
+    val cfg = ConfigLoaderBuilder.defaultWithoutPropertySources()
+      .addMapSource(mapOf("r" to "-10..-5"))
+      .build()
+      .loadConfigOrThrow<Cfg>()
+    cfg.r shouldBe IntRange(-10, -5)
+  }
+
+  test("LongRange should accept negative endpoints") {
+    data class Cfg(val r: LongRange)
+    val cfg = ConfigLoaderBuilder.defaultWithoutPropertySources()
+      .addMapSource(mapOf("r" to "-1000..1000"))
+      .build()
+      .loadConfigOrThrow<Cfg>()
+    cfg.r shouldBe LongRange(-1000L, 1000L)
+  }
+
+  test("positive ranges still decode") {
+    data class Cfg(val r: IntRange)
+    val cfg = ConfigLoaderBuilder.defaultWithoutPropertySources()
+      .addMapSource(mapOf("r" to "1..10"))
+      .build()
+      .loadConfigOrThrow<Cfg>()
+    cfg.r shouldBe IntRange(1, 10)
+  }
+})


### PR DESCRIPTION
## Summary
The numeric range pattern was \`(\d+)\.\.(\d+)\`, so \`-5..5\` failed to decode even though \`IntRange(-5, 5)\` and \`LongRange(-1000, 1000)\` are perfectly valid Kotlin ranges. Allow an optional leading \`-\` on both endpoints.

## Test plan
- [x] New \`RangeDecodersTest\` covers \`IntRange\` with one negative endpoint, with both negative, \`LongRange\` with negative endpoint, and the regression case for the original positive-range path.
- [x] \`:hoplite-core:test\` passes; existing positive-range test still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)