### PR TITLE
Use string concatenation in MonthDayDecoder instead of prependIndent

### DIFF
--- a/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/decoder/dates.kt
+++ b/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/decoder/dates.kt
@@ -177,7 +177,11 @@ class MonthDayDecoder : NonNullableLeafDecoder<MonthDay> {
                               type: KType,
                               context: DecoderContext): ConfigResult<MonthDay> = when (node) {
     is StringNode -> runCatching {
-      MonthDay.parse(node.value.removePrefix("--").prependIndent("--"))
+      // Accept either `--MM-dd` (the canonical MonthDay form) or `MM-dd` by normalising to the
+      // dashed prefix. Previously this used String.prependIndent("--"), which is a multi-line
+      // indentation helper — for single-line input it happens to produce the same result, but
+      // it's the wrong tool for the job and breaks for inputs containing a newline.
+      MonthDay.parse("--" + node.value.removePrefix("--"))
     }.toValidated {
       ConfigFailure.DecodeError(node, type)
     }


### PR DESCRIPTION
## Summary
\`MonthDayDecoder\` was building the dashed prefix with:
\`\`\`kotlin
MonthDay.parse(node.value.removePrefix("--").prependIndent("--"))
\`\`\`
\`String.prependIndent\` is a multi-line indentation helper — for a single-line scalar config value it happens to produce the same output as \`"--" + value\`, but it's the wrong tool for the job and would produce surprising results for inputs containing a newline (e.g. \`"a\nb".prependIndent("--")\` returns \`"--a\n--b"\`).

Switch to plain string concatenation, which is what the code obviously wanted.

## Test plan
- [x] Existing \`MonthDayTest\` still passes (covers both \`--MM-dd\` and \`MM-dd\` input forms).
- [x] \`:hoplite-core:test\` and \`:hoplite-yaml:test\` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)