### PR TITLE
Keep acronyms together in SnakeCase / KebabCase param mappers

### DIFF
--- a/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/ParameterMapper.kt
+++ b/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/ParameterMapper.kt
@@ -62,6 +62,8 @@ object AliasAnnotationParamMapper : ParameterMapper {
  * the snake case equivalent.
  *
  * For example, camelCasePilsen will become snake_case_pilsen.
+ * Acronyms are kept as a single segment, so URLConfig becomes url_config
+ * and myURL becomes my_url (matching the Spring/Jackson convention).
  *
  * When using the [PathNormalizer] (which is enabled by default), this mapper is unnecessary.
  */
@@ -69,13 +71,7 @@ object SnakeCaseParamMapper : ParameterMapper {
 
   override fun map(param: KParameter, constructor: KFunction<Any>, kclass: KClass<*>): Set<String> {
     val name = param.name ?: return emptySet()
-    val snake = name.fold("") { acc, char ->
-      when {
-        char.isUpperCase() && acc.isEmpty() -> char.lowercaseChar().toString()
-        char.isUpperCase() -> acc + "_" + char.lowercaseChar()
-        else -> acc + char
-      }
-    }
+    val snake = splitOnWordBoundaries(name).joinToString("_")
     val trailingDigits = snake.trailingDigits()
     val lastNumberVariant =
       if (trailingDigits.isEmpty()) null else snake.removeSuffix(trailingDigits) + "_" + trailingDigits
@@ -88,6 +84,8 @@ object SnakeCaseParamMapper : ParameterMapper {
  * the kebab case equivalent.
  *
  * For example, camelCasePilsen will become kebab-case-pilsen.
+ * Acronyms are kept as a single segment, so URLConfig becomes url-config
+ * and myURL becomes my-url (matching the Spring/Jackson convention).
  *
  * When using the [PathNormalizer] (which is enabled by default), this mapper is unnecessary.
  */
@@ -95,18 +93,36 @@ object KebabCaseParamMapper : ParameterMapper {
 
   override fun map(param: KParameter, constructor: KFunction<Any>, kclass: KClass<*>): Set<String> {
     val name = param.name ?: return emptySet()
-    val kebab = name.fold("") { acc, char ->
-      when {
-        char.isUpperCase() && acc.isEmpty() -> char.lowercaseChar().toString()
-        char.isUpperCase() -> acc + "-" + char.lowercaseChar()
-        else -> acc + char
-      }
-    }
+    val kebab = splitOnWordBoundaries(name).joinToString("-")
     val trailingDigits = kebab.trailingDigits()
     val lastNumberVariant =
       if (trailingDigits.isEmpty()) null else kebab.removeSuffix(trailingDigits) + "-" + trailingDigits
     return setOfNotNull(kebab, lastNumberVariant)
   }
+}
+
+/**
+ * Splits a camelCase / PascalCase identifier into its constituent words, lowercased. Acronyms
+ * are kept as a single word: `URLConfig` -> `["url", "config"]`, `myURL` -> `["my", "url"]`,
+ * `XMLHttpRequest` -> `["xml", "http", "request"]`. The previous implementation inserted a
+ * separator before every uppercase letter, producing `u_r_l_config` from `URLConfig`.
+ */
+private fun splitOnWordBoundaries(name: String): List<String> {
+  if (name.isEmpty()) return emptyList()
+  val parts = mutableListOf<StringBuilder>()
+  parts.add(StringBuilder())
+  for (i in name.indices) {
+    val c = name[i]
+    val startsNewWord = i > 0 && c.isUpperCase() && (
+      // boundary between lowercase/digit and uppercase: `myURL` -> `my|URL`
+      !name[i - 1].isUpperCase() ||
+      // boundary at the end of an acronym: `URLConfig` -> `URL|Config`
+      (i + 1 < name.length && name[i + 1].isLowerCase())
+    )
+    if (startsNewWord) parts.add(StringBuilder())
+    parts.last().append(c.lowercaseChar())
+  }
+  return parts.map { it.toString() }
 }
 
 private fun String.trailingDigits(): String {

--- a/hoplite-core/src/test/kotlin/com/sksamuel/hoplite/CaseMapperAcronymsTest.kt
+++ b/hoplite-core/src/test/kotlin/com/sksamuel/hoplite/CaseMapperAcronymsTest.kt
@@ -1,0 +1,53 @@
+package com.sksamuel.hoplite
+
+import io.kotest.assertions.assertSoftly
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import kotlin.reflect.KParameter
+
+class CaseMapperAcronymsTest : FunSpec({
+
+  // Lock in the Spring/Jackson convention for acronyms in parameter names. The previous
+  // implementation inserted a separator before every uppercase letter, so `URLConfig` produced
+  // `u_r_l_config` and `myURL` produced `my_u_r_l`. Acronyms should now be kept as a single
+  // segment, matching what users typically expect.
+  data class Config(
+    val URLConfig: String,
+    val myURL: String,
+    val XMLHttpRequest: String,
+    val parseHTTPRequest: String,
+    val URL: String,
+    val A: String,
+    val ABC: String,
+    val httpEndpoint: String,
+  )
+
+  val constructor = Config::class.constructors.first()
+  fun kparam(name: String): KParameter = constructor.parameters.find { it.name == name }!!
+
+  test("SnakeCaseParamMapper keeps consecutive uppercase letters together as acronyms") {
+    assertSoftly {
+      SnakeCaseParamMapper.map(kparam("URLConfig"), constructor, Config::class) shouldBe setOf("url_config")
+      SnakeCaseParamMapper.map(kparam("myURL"), constructor, Config::class) shouldBe setOf("my_url")
+      SnakeCaseParamMapper.map(kparam("XMLHttpRequest"), constructor, Config::class) shouldBe setOf("xml_http_request")
+      SnakeCaseParamMapper.map(kparam("parseHTTPRequest"), constructor, Config::class) shouldBe setOf("parse_http_request")
+      SnakeCaseParamMapper.map(kparam("URL"), constructor, Config::class) shouldBe setOf("url")
+      SnakeCaseParamMapper.map(kparam("A"), constructor, Config::class) shouldBe setOf("a")
+      SnakeCaseParamMapper.map(kparam("ABC"), constructor, Config::class) shouldBe setOf("abc")
+      SnakeCaseParamMapper.map(kparam("httpEndpoint"), constructor, Config::class) shouldBe setOf("http_endpoint")
+    }
+  }
+
+  test("KebabCaseParamMapper keeps consecutive uppercase letters together as acronyms") {
+    assertSoftly {
+      KebabCaseParamMapper.map(kparam("URLConfig"), constructor, Config::class) shouldBe setOf("url-config")
+      KebabCaseParamMapper.map(kparam("myURL"), constructor, Config::class) shouldBe setOf("my-url")
+      KebabCaseParamMapper.map(kparam("XMLHttpRequest"), constructor, Config::class) shouldBe setOf("xml-http-request")
+      KebabCaseParamMapper.map(kparam("parseHTTPRequest"), constructor, Config::class) shouldBe setOf("parse-http-request")
+      KebabCaseParamMapper.map(kparam("URL"), constructor, Config::class) shouldBe setOf("url")
+      KebabCaseParamMapper.map(kparam("A"), constructor, Config::class) shouldBe setOf("a")
+      KebabCaseParamMapper.map(kparam("ABC"), constructor, Config::class) shouldBe setOf("abc")
+      KebabCaseParamMapper.map(kparam("httpEndpoint"), constructor, Config::class) shouldBe setOf("http-endpoint")
+    }
+  }
+})

--- a/hoplite-core/src/test/kotlin/com/sksamuel/hoplite/KebabCaseParamMapperTest.kt
+++ b/hoplite-core/src/test/kotlin/com/sksamuel/hoplite/KebabCaseParamMapperTest.kt
@@ -32,7 +32,8 @@ class KebabCaseParamMapperTest : StringSpec() {
         KebabCaseParamMapper.map(kparam("TitleCase"), constructor, Config::class) shouldBe setOf("title-case")
         KebabCaseParamMapper.map(kparam("foo123"), constructor, Config::class) shouldBe setOf("foo-123", "foo123")
         KebabCaseParamMapper.map(kparam("foo123BarFaz"), constructor, Config::class) shouldBe setOf("foo123-bar-faz")
-        KebabCaseParamMapper.map(kparam("myDSLClass"), constructor, Config::class) shouldBe setOf("my-d-s-l-class")
+        // Acronyms are kept as a single segment: previously this produced "my-d-s-l-class".
+        KebabCaseParamMapper.map(kparam("myDSLClass"), constructor, Config::class) shouldBe setOf("my-dsl-class")
       }
     }
   }

--- a/hoplite-core/src/test/kotlin/com/sksamuel/hoplite/SnakeCaseParamMapperTest.kt
+++ b/hoplite-core/src/test/kotlin/com/sksamuel/hoplite/SnakeCaseParamMapperTest.kt
@@ -31,7 +31,8 @@ class SnakeCaseParamMapperTest : StringSpec() {
         SnakeCaseParamMapper.map(kparam("TitleCase"), constructor, Config::class) shouldBe setOf("title_case")
         SnakeCaseParamMapper.map(kparam("foo123"), constructor, Config::class) shouldBe setOf("foo123", "foo_123")
         SnakeCaseParamMapper.map(kparam("foo123BarFaz"), constructor, Config::class) shouldBe setOf("foo123_bar_faz")
-        SnakeCaseParamMapper.map(kparam("myDSLClass"), constructor, Config::class) shouldBe setOf("my_d_s_l_class")
+        // Acronyms are kept as a single segment: previously this produced "my_d_s_l_class".
+        SnakeCaseParamMapper.map(kparam("myDSLClass"), constructor, Config::class) shouldBe setOf("my_dsl_class")
       }
     }
   }


### PR DESCRIPTION
## Summary
The previous fold in \`SnakeCaseParamMapper\` and \`KebabCaseParamMapper\` inserted a separator before *every* uppercase letter unconditionally, so consecutive uppercase letters got broken into single-character segments:

| input | before | after |
|---|---|---|
| \`URLConfig\` | \`u_r_l_config\` | \`url_config\` |
| \`myURL\` | \`my_u_r_l\` | \`my_url\` |
| \`XMLHttpRequest\` | \`x_m_l_http_request\` | \`xml_http_request\` |
| \`parseHTTPRequest\` | \`parse_h_t_t_p_request\` | \`parse_http_request\` |

## Fix
Replace the per-character fold with a word-boundary split that mirrors the Spring/Jackson convention: insert a separator before an uppercase letter when the previous character is lowercase, OR when we're at the end of an acronym (previous char uppercase AND next char lowercase). Plain camelCase and existing snake/kebab inputs are unchanged.

## Test plan
- [x] Existing \`SnakeCaseParamMapperTest\` / \`KebabCaseParamMapperTest\` updated: the \`myDSLClass\` expectation was \`"my_d_s_l_class"\` (locking in the broken behaviour) and is now \`"my_dsl_class"\`.
- [x] New \`CaseMapperAcronymsTest\` covers the wider matrix: \`URLConfig\`, \`myURL\`, \`XMLHttpRequest\`, \`parseHTTPRequest\`, \`URL\`, \`A\`, \`ABC\`, \`httpEndpoint\`, in both snake and kebab forms.
- [x] \`:hoplite-core:test\`, \`:hoplite-yaml:test\`, \`:hoplite-json:test\`, \`:hoplite-hocon:test\` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)