### PR TITLE
Make SystemPropertiesPropertySource prefix configurable (#545)

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,9 @@ be used for the same purpose.
 The `SystemPropertiesPropertySource` provides config through system properties that are prefixed with `config.override.`.
 For example, starting your JVM with `-Dconfig.override.database.name` would override a config key of `database.name` residing in a file.
 
+The prefix may be customized by passing a `prefix` argument to the constructor, or set to an empty string to expose
+all system properties.
+
 
 ### UserSettingsPropertySource
 

--- a/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/sources/SystemPropertiesPropertySource.kt
+++ b/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/sources/SystemPropertiesPropertySource.kt
@@ -11,13 +11,17 @@ import java.util.Properties
 
 /**
  * An implementation of [PropertySource] that provides config through system properties
- * that are prefixed with 'config.override.'
+ * that are prefixed with [prefix] (defaults to 'config.override.').
  *
  * In other words, if a System property is defined 'config.override.user.name=sam' then
  * the property 'user.name=sam' is made available.
+ *
+ * The [prefix] may be overridden to use a different value, or set to an empty string
+ * to expose all system properties.
  */
 open class SystemPropertiesPropertySource(
-  private val systemPropertiesMap: () -> Map<String, String> = { System.getProperties().toStringMap() }
+  private val systemPropertiesMap: () -> Map<String, String> = { System.getProperties().toStringMap() },
+  private val prefix: String = DEFAULT_PREFIX,
 ) : PropertySource {
 
   override fun source(): String = "System Properties"
@@ -30,7 +34,7 @@ open class SystemPropertiesPropertySource(
   }
 
   companion object : SystemPropertiesPropertySource() {
-    private const val prefix = "config.override."
+    const val DEFAULT_PREFIX = "config.override."
 
     // for backwards compatibility with Java from when SystemPropertiesPropertySource was an `object`
     @Suppress("unused")

--- a/hoplite-core/src/test/kotlin/com/sksamuel/hoplite/SystemPropertiesPropertySourceTest.kt
+++ b/hoplite-core/src/test/kotlin/com/sksamuel/hoplite/SystemPropertiesPropertySourceTest.kt
@@ -50,6 +50,48 @@ class SystemPropertiesPropertySourceTest : FunSpec() {
       }
     }
 
+    test("supports a custom prefix") {
+      data class TestConfig(val a: String, val b: Int)
+
+      val config = ConfigLoader {
+        addPropertySource(
+          SystemPropertiesPropertySource(
+            systemPropertiesMap = {
+              mapOf("my.prefix.a" to "Overridden by system prop")
+            },
+            prefix = "my.prefix.",
+          )
+        )
+        addPropertySource(
+          PropertySource.string(
+            """
+          a = A value
+          b = 42
+          """.trimIndent(), "props"
+          )
+        )
+      }.loadConfigOrThrow<TestConfig>()
+
+      config shouldBe TestConfig("Overridden by system prop", 42)
+    }
+
+    test("supports an empty prefix to expose all system properties") {
+      data class TestConfig(val a: String, val b: Int)
+
+      val config = ConfigLoader {
+        addPropertySource(
+          SystemPropertiesPropertySource(
+            systemPropertiesMap = {
+              mapOf("a" to "Overridden by system prop", "b" to "42")
+            },
+            prefix = "",
+          )
+        )
+      }.loadConfigOrThrow<TestConfig>()
+
+      config shouldBe TestConfig("Overridden by system prop", 42)
+    }
+
     test("properties toStringMap extension function ignores non-string types") {
       Properties().apply {
         setProperty("foo", "bar")


### PR DESCRIPTION
## Summary
- Closes #545.
- Adds a `prefix` constructor parameter to `SystemPropertiesPropertySource` (default `"config.override."`, exposed as `companion.DEFAULT_PREFIX`) so it can be customized like `EnvironmentVariablesPropertySource`.
- Pass `prefix = ""` to expose all system properties.
- Fully backwards compatible — the default singleton (used by `defaultPropertySources()`) keeps the existing `config.override.` behavior.

## Test plan
- [x] Existing `SystemPropertiesPropertySourceTest` cases still pass.
- [x] New test: custom prefix overrides config (`my.prefix.a` → `a`).
- [x] New test: empty prefix exposes all system properties.

🤖 Generated with [Claude Code](https://claude.com/claude-code)