### PR TITLE
SecretFilesPreprocessor: switch placeholder format to ${secret:key}

### DIFF
--- a/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/preprocessor/SecretFilesPreprocessor.kt
+++ b/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/preprocessor/SecretFilesPreprocessor.kt
@@ -1,34 +1,39 @@
-package com.polecatworks.kotlin.k8smicro.utils
+@file:Suppress("RegExpRedundantEscape")
 
-import com.sksamuel.hoplite.*
+package com.sksamuel.hoplite.preprocessor
+
+import com.sksamuel.hoplite.ConfigResult
+import com.sksamuel.hoplite.DecoderContext
+import com.sksamuel.hoplite.Node
+import com.sksamuel.hoplite.PrimitiveNode
+import com.sksamuel.hoplite.StringNode
 import com.sksamuel.hoplite.fp.valid
-import com.sksamuel.hoplite.preprocessor.TraversingPrimitivePreprocessor
 import java.nio.file.Path
 import kotlin.io.path.readText
 
-class SecretFilesPreprocessor(private val basePath: Path): TraversingPrimitivePreprocessor() {
-    override fun handle(node: PrimitiveNode, context: DecoderContext): ConfigResult<Node> = when (node) {
-        is StringNode -> {
-            val value = regex.replace(node.value) {
-                val key = it.groupValues[1]
-                basePath.resolve(key).readText()
-            }
-            node.copy(value).valid()
-        }
-        else -> node.valid()
+/**
+ * Replaces strings of the form `${secret:key}` with the contents of the file at
+ * `<basePath>/<key>`. A trailing line terminator (`\n` or `\r\n`) is stripped, so
+ * editor- or shell-added newlines do not leak into config values.
+ *
+ * Useful for Docker / Kubernetes-style mounted secrets where each secret is a
+ * separate file inside a directory.
+ */
+class SecretFilesPreprocessor(private val basePath: Path) : TraversingPrimitivePreprocessor() {
+
+  constructor(basePath: String) : this(Path.of(basePath))
+
+  // Redundant escaping required for Android support.
+  private val regex = "\\$\\{secret:(.+?)\\}".toRegex()
+
+  override fun handle(node: PrimitiveNode, context: DecoderContext): ConfigResult<Node> = when (node) {
+    is StringNode -> {
+      val replaced = regex.replace(node.value) { match ->
+        val key = match.groupValues[1]
+        basePath.resolve(key).readText().trimEnd('\r', '\n')
+      }
+      if (replaced == node.value) node.valid() else node.copy(value = replaced).valid()
     }
-
-
-    // Redundant escaping required for Android support.
-    private val regex = "\\$\\{(.*?)\\}".toRegex()
-
-    companion object {
-        operator fun invoke(basePath: String): SecretFilesPreprocessor {
-            val x = Path.of(basePath)
-            println("Secrets DIR =$x")
-            return SecretFilesPreprocessor(x)
-        }
-
-        operator fun invoke(path: Path) = SecretFilesPreprocessor(path)
-    }
+    else -> node.valid()
+  }
 }

--- a/hoplite-core/src/test/kotlin/com/sksamuel/hoplite/preprocessor/SecretFilesPreprocessorTest.kt
+++ b/hoplite-core/src/test/kotlin/com/sksamuel/hoplite/preprocessor/SecretFilesPreprocessorTest.kt
@@ -1,22 +1,122 @@
+package com.sksamuel.hoplite.preprocessor
 
+import com.sksamuel.hoplite.ConfigLoaderBuilder
+import com.sksamuel.hoplite.PropertySource
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.engine.spec.tempdir
+import io.kotest.matchers.shouldBe
+import java.io.File
 
+class SecretFilesPreprocessorTest : FunSpec({
 
-class SecretFilesPreprocessorTest : StringSpec() {
-  init {
-    "secret files preprocessor should replace values with secrets from files" {
-        data class Config(
-            val a: String,
-            val b: String,
-            )
-
-        val preprocessor = SecretFilesPreprocessor("secrets")
-
-        val config = ConfigLoaderBuilder.default()
-            .addPreprocessor(preprocessor)
-            .build()
-            .loadConfigOrThrow<Config>("/myconfig.yaml")
-
-        config shouldBe Config(a = "Im a config", b = "Im a secret")
-    }
+  fun File.writeSecret(name: String, value: String) {
+    resolve(name).writeText(value)
   }
-}
+
+  test("resolves a single \${secret:key} placeholder from a file") {
+    val secrets = tempdir().apply { writeSecret("apiKey", "abc-123") }
+
+    data class Config(val apiKey: String)
+
+    val config = ConfigLoaderBuilder.default()
+      .addPreprocessor(SecretFilesPreprocessor(secrets.toPath()))
+      .addPropertySource(PropertySource.string("apiKey=\${secret:apiKey}", "props"))
+      .build()
+      .loadConfigOrThrow<Config>()
+
+    config shouldBe Config(apiKey = "abc-123")
+  }
+
+  test("resolves multiple secrets from separate files within the same config") {
+    val secrets = tempdir().apply {
+      writeSecret("apiKey", "abc-123")
+      writeSecret("dbPassword", "hunter2")
+      writeSecret("oauthClientSecret", "client-shhh")
+    }
+
+    data class Db(val user: String, val password: String)
+    data class Config(val apiKey: String, val oauth: String, val db: Db)
+
+    val config = ConfigLoaderBuilder.default()
+      .addPreprocessor(SecretFilesPreprocessor(secrets.toPath()))
+      .addPropertySource(
+        PropertySource.string(
+          """
+          apiKey=${'$'}{secret:apiKey}
+          oauth=${'$'}{secret:oauthClientSecret}
+          db.user=admin
+          db.password=${'$'}{secret:dbPassword}
+          """.trimIndent(),
+          "props"
+        )
+      )
+      .build()
+      .loadConfigOrThrow<Config>()
+
+    config shouldBe Config(
+      apiKey = "abc-123",
+      oauth = "client-shhh",
+      db = Db(user = "admin", password = "hunter2"),
+    )
+  }
+
+  test("strips a single trailing newline from secret files (\\n and \\r\\n)") {
+    val secrets = tempdir().apply {
+      writeSecret("unix", "unix-value\n")
+      writeSecret("windows", "windows-value\r\n")
+      writeSecret("none", "no-newline")
+    }
+
+    data class Config(val unix: String, val windows: String, val none: String)
+
+    val config = ConfigLoaderBuilder.default()
+      .addPreprocessor(SecretFilesPreprocessor(secrets.toPath()))
+      .addPropertySource(
+        PropertySource.string(
+          """
+          unix=${'$'}{secret:unix}
+          windows=${'$'}{secret:windows}
+          none=${'$'}{secret:none}
+          """.trimIndent(),
+          "props"
+        )
+      )
+      .build()
+      .loadConfigOrThrow<Config>()
+
+    config shouldBe Config(unix = "unix-value", windows = "windows-value", none = "no-newline")
+  }
+
+  test("supports multiple secret references within a single value") {
+    val secrets = tempdir().apply {
+      writeSecret("user", "alice")
+      writeSecret("host", "db.internal")
+    }
+
+    data class Config(val url: String)
+
+    val config = ConfigLoaderBuilder.default()
+      .addPreprocessor(SecretFilesPreprocessor(secrets.toPath()))
+      .addPropertySource(
+        PropertySource.string("url=jdbc://\${secret:user}@\${secret:host}/db", "props")
+      )
+      .build()
+      .loadConfigOrThrow<Config>()
+
+    config shouldBe Config(url = "jdbc://alice@db.internal/db")
+  }
+
+  test("accepts a string base path via the convenience constructor") {
+    val secrets = tempdir().apply { writeSecret("apiKey", "abc-123") }
+
+    data class Config(val apiKey: String)
+
+    val config = ConfigLoaderBuilder.default()
+      .addPreprocessor(SecretFilesPreprocessor(secrets.absolutePath))
+      .addPropertySource(PropertySource.string("apiKey=\${secret:apiKey}", "props"))
+      .build()
+      .loadConfigOrThrow<Config>()
+
+    config shouldBe Config(apiKey = "abc-123")
+  }
+})

--- a/hoplite-core/src/test/resources/myconfig.yaml
+++ b/hoplite-core/src/test/resources/myconfig.yaml
@@ -1,2 +1,0 @@
-a: im a config
-b: ${secretB}

--- a/hoplite-core/src/test/resources/secrets/secretB
+++ b/hoplite-core/src/test/resources/secrets/secretB
@@ -1,1 +1,0 @@
-Im a secret


### PR DESCRIPTION
## Summary
- `SecretFilesPreprocessor` previously matched the bare `${key}` form, which clashes with every other `${...}` preprocessor (env/sysprop, lookup, etc.). Switched to the unambiguous `${secret:key}` form so it composes cleanly.
- Moved the class into `com.sksamuel.hoplite.preprocessor` (matching its file location).
- Dropped the debug `println` in the String-arg companion factory and folded the String overload into a secondary constructor.
- Strip a single trailing `\n` / `\r\n` from secret files so editor-added newlines don't leak into config values.

## Tests
The previous test had no package, no imports, and depended on `hoplite-yaml` which is not on the `hoplite-core` classpath, so it never compiled. Replaced with comprehensive coverage that writes secrets into a `tempdir()`:
- single `${secret:key}` placeholder is replaced by the file contents
- multiple secrets, each in its own file, are resolved within one config (including a nested data class)
- trailing `\n` and `\r\n` are stripped, files without trailing newlines are preserved verbatim
- multiple secret references within the same value are all replaced
- the String-path convenience constructor works

## Test plan
- [x] `./gradlew :hoplite-core:test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)