### PR TITLE
Fix InformationUnit.Octets ratio (1 octet == 1 byte)

### DIFF
--- a/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/decoder/SizeInBytesDecoder.kt
+++ b/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/decoder/SizeInBytesDecoder.kt
@@ -48,7 +48,12 @@ sealed class InformationUnit {
   }
 
   object Octets : InformationUnit() {
-    override val ratioToPrimary = 1 / 8.0
+    // An octet is, by definition, 8 bits — i.e. exactly one byte. The previous
+    // ratio of 1/8.0 confused octets with bits and silently produced wrong
+    // results: parse("5o") yielded SizeInBytes(0) (5 * 0.125 = 0.625 truncated
+    // to 0), and bytes.octets() multiplied by 8 instead of returning the same
+    // count.
+    override val ratioToPrimary = 1.0
     override val symbol = "o"
   }
 

--- a/hoplite-core/src/test/kotlin/com/sksamuel/hoplite/decoder/SizeInBytesDecoderTest.kt
+++ b/hoplite-core/src/test/kotlin/com/sksamuel/hoplite/decoder/SizeInBytesDecoderTest.kt
@@ -21,4 +21,27 @@ class SizeInBytesDecoderTest : FunSpec({
       SizeInBytes((size * unit.ratioToPrimary).toLong()).convert(unit) shouldBe size
     }
   }
+
+  // Anchors the actual definition of each unit, independent of the round-trip test
+  // above (which would happily round-trip with a wrong constant in both directions).
+  test("each unit has the correct ratio to one byte") {
+    InformationUnit.Bytes.ratioToPrimary shouldBe 1.0
+    InformationUnit.Octets.ratioToPrimary shouldBe 1.0   // 1 octet == 8 bits == 1 byte
+    InformationUnit.Bits.ratioToPrimary shouldBe 0.125   // 1 bit == 1/8 byte
+    InformationUnit.Kilobytes.ratioToPrimary shouldBe 1000.0
+    InformationUnit.Kibibytes.ratioToPrimary shouldBe 1024.0
+  }
+
+  test("parse converts string-with-unit to byte count") {
+    SizeInBytes.parse("5B")?.size shouldBe 5L
+    SizeInBytes.parse("5o")?.size shouldBe 5L  // previously yielded 0 because octets had ratio 1/8
+    SizeInBytes.parse("8bit")?.size shouldBe 1L
+    SizeInBytes.parse("2KB")?.size shouldBe 2000L
+    SizeInBytes.parse("2KiB")?.size shouldBe 2048L
+  }
+
+  test("octets() returns the same count as bytes() since 1 octet == 1 byte") {
+    val size = SizeInBytes(64)
+    size.octets() shouldBe size.bytes()
+  }
 })


### PR DESCRIPTION
## Summary
`InformationUnit.Octets` had `ratioToPrimary = 1/8.0`, confusing octets with bits. An [octet](https://en.wikipedia.org/wiki/Octet_(computing)) is — by definition — 8 bits, i.e. exactly one byte.

With the old ratio:
- `SizeInBytes.parse(\"5o\")` returned `SizeInBytes(0)` because `5 * 0.125 = 0.625` was truncated by `.toLong()`.
- `SizeInBytes(8).octets()` returned `64` instead of `8`.

## Tests
The existing test only round-tripped parse → convert, which happily round-trips with the wrong constant in both directions. Added explicit assertions:
- Each unit's `ratioToPrimary` is the value it should be (`Octets = 1.0`, `Bits = 0.125`, `Kilobytes = 1000.0`, `Kibibytes = 1024.0`).
- `parse(\"5o\")` returns 5 bytes, `parse(\"8bit\")` returns 1 byte, `parse(\"2KB\")` returns 2000 bytes, `parse(\"2KiB\")` returns 2048 bytes.
- `octets() == bytes()` for any `SizeInBytes`.

> **Note:** PR is opened against master, but master currently does not compile because of the test file from #470 (which my PR #547 fixes). Once #547 lands, this branch builds clean.

## Test plan
- [x] `./gradlew :hoplite-core:test --tests SizeInBytesDecoderTest` (verified locally with #547's source-file fix applied).

🤖 Generated with [Claude Code](https://claude.com/claude-code)