### PR TITLE
Close input stream in ConfigFilePropertySource on the empty-file paths

### DIFF
--- a/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/sources/ConfigFilePropertySource.kt
+++ b/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/sources/ConfigFilePropertySource.kt
@@ -43,11 +43,18 @@ class ConfigFilePropertySource(
         when {
           input == null && optional -> Undefined.valid()
           input == null -> ConfigFailure.UnknownSource(config.describe()).invalid()
-          input.available() == 0 && (allowEmpty || context.allowEmptyConfigFiles) -> Undefined.valid()
-          input.available() == 0 -> ConfigFailure.EmptyConfigSource(config).invalid()
-          else -> runCatching {
-            input.use { parser.load(it, config.describe()) }
-          }.toValidated { ConfigFailure.PropertySourceFailure("Could not parse ${config.describe()}", it) }
+          // Wrap every branch that touches `input` in `.use {}` so the stream is closed on
+          // every path — including the empty-file branches, which previously leaked the
+          // stream when allowEmpty was true (Undefined) or false (EmptyConfigSource).
+          else -> input.use {
+            when {
+              it.available() == 0 && (allowEmpty || context.allowEmptyConfigFiles) -> Undefined.valid()
+              it.available() == 0 -> ConfigFailure.EmptyConfigSource(config).invalid()
+              else -> runCatching {
+                parser.load(it, config.describe())
+              }.toValidated { ex -> ConfigFailure.PropertySourceFailure("Could not parse ${config.describe()}", ex) }
+            }
+          }
         }
       }
     }

--- a/hoplite-core/src/test/kotlin/com/sksamuel/hoplite/sources/ConfigFilePropertySourceTest.kt
+++ b/hoplite-core/src/test/kotlin/com/sksamuel/hoplite/sources/ConfigFilePropertySourceTest.kt
@@ -1,0 +1,65 @@
+package com.sksamuel.hoplite.sources
+
+import com.sksamuel.hoplite.ConfigSource
+import com.sksamuel.hoplite.PropertySourceContext
+import com.sksamuel.hoplite.parsers.DefaultParserRegistry
+import com.sksamuel.hoplite.parsers.PropsParser
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.engine.spec.tempdir
+import io.kotest.matchers.shouldBe
+import java.io.IOException
+import java.io.InputStream
+import java.util.concurrent.atomic.AtomicReference
+
+class ConfigFilePropertySourceTest : FunSpec({
+
+  // Wraps PathSource so we can capture the InputStream it hands back to
+  // ConfigFilePropertySource and assert that the stream is closed afterwards.
+  // Reading from a closed FileInputStream / ChannelInputStream throws IOException.
+  class CapturingPathSource(
+    private val delegate: ConfigSource.PathSource,
+    val captured: AtomicReference<InputStream> = AtomicReference()
+  ) : ConfigSource() {
+    override fun describe() = delegate.describe()
+    override fun ext() = delegate.ext()
+    override fun open(optional: Boolean) = delegate.open(optional).map { stream ->
+      stream?.also { captured.set(it) }
+    }
+  }
+
+  fun assertClosed(captured: AtomicReference<InputStream>) {
+    val stream = captured.get() ?: error("expected ConfigFilePropertySource to open the file")
+    val readAfter = runCatching { stream.read() }
+    readAfter.isFailure shouldBe true
+    (readAfter.exceptionOrNull() is IOException) shouldBe true
+  }
+
+  val context = PropertySourceContext(DefaultParserRegistry(mapOf("props" to PropsParser())))
+
+  test("closes the input stream after parsing a non-empty config (#540 covered this for one path)") {
+    val file = tempdir().resolve("conf.props").apply { writeText("a=1\nb=2\n") }
+    val src = CapturingPathSource(ConfigSource.PathSource(file.toPath()))
+
+    ConfigFilePropertySource(src, optional = false, allowEmpty = false).node(context)
+
+    assertClosed(src.captured)
+  }
+
+  test("closes the input stream when the file is empty and allowEmpty=true") {
+    val file = tempdir().resolve("conf.props").apply { writeText("") }
+    val src = CapturingPathSource(ConfigSource.PathSource(file.toPath()))
+
+    ConfigFilePropertySource(src, optional = false, allowEmpty = true).node(context)
+
+    assertClosed(src.captured)
+  }
+
+  test("closes the input stream when the file is empty and allowEmpty=false (returns EmptyConfigSource)") {
+    val file = tempdir().resolve("conf.props").apply { writeText("") }
+    val src = CapturingPathSource(ConfigSource.PathSource(file.toPath()))
+
+    ConfigFilePropertySource(src, optional = false, allowEmpty = false).node(context)
+
+    assertClosed(src.captured)
+  }
+})


### PR DESCRIPTION
## Summary
`ConfigSource.open()` returns an `InputStream` the caller must close. The non-empty branch in `ConfigFilePropertySource.node()` already wraps its `parser.load(...)` in `.use {}`, but the two empty-file branches (`allowEmpty` → `Undefined`, `!allowEmpty` → `EmptyConfigSource`) just returned without ever closing the stream — leaking one file descriptor per empty-file load.

Moved the `.use {}` up so it covers every branch that touches `input`.

This is the same class of bug as recently closed in #532, #533, #539, #540, but on the empty-file code path of `ConfigFilePropertySource` specifically.

## Tests
New `ConfigFilePropertySourceTest` wraps `PathSource` to capture the stream the property source opens, then asserts `read()` throws `IOException` after `node()` returns. Three cases:
- non-empty file (regression — already worked, but now anchored)
- empty file with `allowEmpty = true`
- empty file with `allowEmpty = false`

Verified the two empty-file tests fail against the un-patched source.

## Test plan
- [x] `./gradlew :hoplite-core:test --tests ConfigFilePropertySourceTest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)