### PR TITLE
hoplite-aws-kotlin: paginate ParameterStorePathPreprocessor results

### DIFF
--- a/hoplite-aws-kotlin/src/main/kotlin/com/sksamuel/hoplite/aws/kotlin/ParameterStorePathPreprocessor.kt
+++ b/hoplite-aws-kotlin/src/main/kotlin/com/sksamuel/hoplite/aws/kotlin/ParameterStorePathPreprocessor.kt
@@ -34,11 +34,24 @@ class ParameterStorePathPreprocessor(
 
   private fun fetchParameterStoreValues(): Result<List<Parameter>> = runCatching {
     runBlocking {
-      client.getParametersByPath {
+      val initial = GetParametersByPathRequest {
         path = this@ParameterStorePathPreprocessor.path
         configure()
-      }.parameters
-        ?: emptyList()
+      }
+      // The SSM API caps each response at 10 parameters by default; previously this only
+      // returned the first page, so any path with more than ~10 parameters was effectively
+      // truncated. Walk the nextToken chain so every key under `path` is visible to the
+      // ${ssm:key} substitution. The companion ParameterStorePathPropertySource already
+      // paginates the same way.
+      val all = mutableListOf<Parameter>()
+      var request = initial
+      while (true) {
+        val result = client.getParametersByPath(request)
+        result.parameters?.let { all.addAll(it) }
+        val token = result.nextToken ?: break
+        request = initial.copy { nextToken = token }
+      }
+      all
     }
   }
 


### PR DESCRIPTION
## Summary
The kotlin-SDK SSM API caps each `GetParametersByPath` response at 10 parameters and returns a `nextToken` to walk further pages. `ParameterStorePathPreprocessor` only consumed the first page, so any path holding more than ~10 parameters was silently truncated and `\${ssm:key}` references for later parameters resolved to *Could not find key* with a misleading list of \"available\" parameters.

The companion `ParameterStorePathPropertySource` already paginates the same way (`hoplite-aws-kotlin/.../ParameterStorePathPropertySource.kt:41-50`); this PR mirrors that loop so the two surfaces behave consistently.

## Test plan
- [x] `./gradlew :hoplite-aws-kotlin:test` (existing tests still pass; no integration test added since live SSM / localstack is not in the test setup, but the fix is mechanically equivalent to the property-source's working pagination).

🤖 Generated with [Claude Code](https://claude.com/claude-code)