### PR TITLE
hoplite-yaml: pass the error message to error() instead of a lambda

### DIFF
--- a/hoplite-yaml/src/main/kotlin/com/sksamuel/hoplite/yaml/YamlParser.kt
+++ b/hoplite-yaml/src/main/kotlin/com/sksamuel/hoplite/yaml/YamlParser.kt
@@ -41,7 +41,11 @@ class YamlParser : Parser {
         stream.next() // move past the doc start
         TokenProduction(stream, source, emptyMap(), DotPath.root).first
       }
-      else -> error { "Expected document start at ${stream.current().startMark}" }
+      // kotlin.error has only one overload — `error(message: Any)` — so a trailing-lambda call
+      // would pass the lambda itself as the message, and IllegalStateException would be raised
+      // with `message.toString()` of the lambda (something like "Function0<String>") instead of
+      // the intended text. Use the parenthesised form so the actual string reaches the user.
+      else -> error("Expected document start at ${stream.current().startMark}")
     }
   }
 }


### PR DESCRIPTION
## Summary
`kotlin.error` has only one overload — `error(message: Any): Nothing` — so the trailing-lambda call

```kotlin
error { "Expected document start at ${stream.current().startMark}" }
```

was passing the **lambda itself** as the message. The resulting `IllegalStateException` carried `message.toString()` of the `Function0` (something like `kotlin.jvm.functions.Function0$…@hashcode`) instead of the intended diagnostic, hiding what went wrong from the user.

Switched to the parenthesised form. The else-branch is unreachable from a well-formed SnakeYAML event stream, so no targeted test was added; the fix is mechanical.

## Test plan
- [x] `./gradlew :hoplite-yaml:test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)