### PR TITLE
hoplite-toml: surface TOML parse errors instead of returning a partial result

### DIFF
--- a/hoplite-toml/src/main/kotlin/com/sksamuel/hoplite/toml/TomlParser.kt
+++ b/hoplite-toml/src/main/kotlin/com/sksamuel/hoplite/toml/TomlParser.kt
@@ -23,6 +23,17 @@ class TomlParser : Parser {
   override fun defaultFileExtensions(): List<String> = listOf("toml")
   override fun load(input: InputStream, source: String): Node {
     val result = Toml.parse(input)
+    // Toml.parse returns a result-with-errors object — it does not throw on invalid TOML, it
+    // just gives you whatever it managed to recover. Walking the table after a parse error
+    // silently produces a partial config. Surface the errors so the user is told what went
+    // wrong instead of getting "missing key" failures further down the pipeline.
+    if (result.hasErrors()) {
+      val message = result.errors().joinToString(separator = "\n") { err ->
+        val pos = err.position()
+        if (pos != null) "$source:${pos.line()}:${pos.column()}: ${err.message}" else "$source: ${err.message}"
+      }
+      throw IllegalStateException("Invalid TOML in $source:\n$message")
+    }
     return TableProduction(result, Pos.SourcePos(source), source, DotPath.root)
   }
 }

--- a/hoplite-toml/src/test/kotlin/com/sksamuel/hoplite/toml/PeriodKeyTest.kt
+++ b/hoplite-toml/src/test/kotlin/com/sksamuel/hoplite/toml/PeriodKeyTest.kt
@@ -11,8 +11,8 @@ class PeriodKeyTest : FunSpec() {
 value = 10
 [values]
 "cleanup.policy" = "compact"
-"delete.retention.ms" = "604800000
-""""
+"delete.retention.ms" = "604800000"
+"""
       ConfigLoader.builder()
         .addSource(TomlPropertySource(contents))
         .build()

--- a/hoplite-toml/src/test/kotlin/com/sksamuel/hoplite/toml/TomlParserErrorTest.kt
+++ b/hoplite-toml/src/test/kotlin/com/sksamuel/hoplite/toml/TomlParserErrorTest.kt
@@ -1,0 +1,32 @@
+package com.sksamuel.hoplite.toml
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.string.shouldContain
+
+class TomlParserErrorTest : FunSpec({
+
+  test("parser surfaces errors from invalid TOML instead of returning a partial result") {
+    // Reserved characters / unquoted spaces are invalid in TOML.
+    val invalid = """
+      key1 = "ok"
+      not valid toml here
+      key2 = 42
+    """.trimIndent()
+
+    val ex = shouldThrow<IllegalStateException> {
+      TomlParser().load(invalid.byteInputStream(), "inline.toml")
+    }
+    ex.message shouldContain "Invalid TOML in inline.toml"
+  }
+
+  test("parser still accepts a syntactically-valid document") {
+    val valid = """
+      name = "hoplite"
+      count = 7
+    """.trimIndent()
+
+    // Should not throw.
+    TomlParser().load(valid.byteInputStream(), "inline.toml")
+  }
+})


### PR DESCRIPTION
## Summary
`org.tomlj.Toml.parse` does **not** throw on invalid TOML — it returns a `TomlParseResult` that may contain errors plus whatever it managed to recover. The previous implementation walked the (partial) table and silently produced a config that was missing the broken bits, so users hit confusing *missing key* or wrong-value failures further down the pipeline instead of the actual TOML syntax error.

This PR checks `result.hasErrors()` and throws `IllegalStateException` with the collected errors (one per line, prefixed with `source:line:col` when available).

## Drive-by fix
`PeriodKeyTest`'s fixture contained an unterminated TOML string literal:
```
"delete.retention.ms" = "604800000
""""
```
The previous parser silently dropped the broken section yet still produced a map that happened to contain the expected keys, so the test passed for the wrong reason. With error checking on, the malformed fixture is rejected; the closing quote has been moved onto the same line.

## Tests
- New `TomlParserErrorTest` covers both the throw-on-invalid path and the happy path.
- All other `:hoplite-toml:test` tests still pass after fixing the `PeriodKeyTest` fixture.

## Test plan
- [x] `./gradlew :hoplite-toml:test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)