### PR TITLE
Fix typos: "Uknown", "seperated", "recursivel"

### DIFF
--- a/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/nodes.kt
+++ b/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/nodes.kt
@@ -54,8 +54,8 @@ sealed interface Node {
   operator fun get(index: Int): Node = atIndex(index)
 
   /**
-   * Returns the [Node] at the given path, by recursivel calling [atKey]
-   * for each dot seperated element in the input path.
+   * Returns the [Node] at the given path, by recursively calling [atKey]
+   * for each dot-separated element in the input path.
    */
   fun atPath(path: String): Node {
     val parts = path.split('.')

--- a/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/resolver/context/SystemContextResolver.kt
+++ b/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/resolver/context/SystemContextResolver.kt
@@ -17,7 +17,7 @@ object SystemContextResolver : ContextResolver() {
     return when (path) {
       "processors" -> Runtime.getRuntime().availableProcessors().toString().valid()
       "timestamp" -> System.currentTimeMillis().toString().valid()
-      else -> ConfigFailure.ResolverFailure("Uknown system context path $path").invalid()
+      else -> ConfigFailure.ResolverFailure("Unknown system context path $path").invalid()
     }
   }
 }


### PR DESCRIPTION
## Summary
Two trivial typo fixes:
- `SystemContextResolver`: user-facing error message said *Uknown* — corrected to *Unknown*.
- `Node.atPath` docstring had two adjacent typos: *recursivel* → *recursively*, *seperated* → *separated*.

No behaviour changes.

## Test plan
- [x] Compile-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)