### PR TITLE
MapDecoder: mark key/value paths as used in array-of-objects form

### DIFF
--- a/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/decoder/MapDecoder.kt
+++ b/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/decoder/MapDecoder.kt
@@ -51,8 +51,15 @@ class MapDecoder : NullHandlingDecoder<Map<*, *>> {
                                context: DecoderContext): ConfigResult<Map<*, *>> {
 
       return node.elements.map { el ->
-        kdecoder.decode(el.atKey("key"), kType, context).flatMap { kk ->
-          vdecoder.decode(el.atKey("value"), vType, context).map { vv ->
+        val keyNode = el.atKey("key")
+        val valueNode = el.atKey("value")
+        kdecoder.decode(keyNode, kType, context).flatMap { kk ->
+          vdecoder.decode(valueNode, vType, context).map { vv ->
+            // Mark both subnodes as used so strict mode does not flag the array-of-objects
+            // map form (`[{key: ..., value: ...}, ...]`) as containing unused entries —
+            // matches what decodeFromMap above does for the value path.
+            context.usedPaths.add(keyNode.path)
+            context.usedPaths.add(valueNode.path)
             kk to vv
           }
         }

--- a/hoplite-vavr/src/main/kotlin/com/sksamuel/hoplite/decoder/vavr/MapDecoder.kt
+++ b/hoplite-vavr/src/main/kotlin/com/sksamuel/hoplite/decoder/vavr/MapDecoder.kt
@@ -47,8 +47,14 @@ class MapDecoder : NullHandlingDecoder<Map<*, *>> {
                                vdecoder: Decoder<V>,
                                context: DecoderContext): ConfigResult<Map<*, *>> =
       node.elements.map { el ->
-        kdecoder.decode(el.atKey("key"), kType, context).flatMap { kk ->
-          vdecoder.decode(el.atKey("value"), vType, context).map { vv ->
+        val keyNode = el.atKey("key")
+        val valueNode = el.atKey("value")
+        kdecoder.decode(keyNode, kType, context).flatMap { kk ->
+          vdecoder.decode(valueNode, vType, context).map { vv ->
+            // Mark both subnodes as used so strict mode does not flag the array-of-objects
+            // map form (`[{key: ..., value: ...}, ...]`) as containing unused entries.
+            context.usedPaths.add(keyNode.path)
+            context.usedPaths.add(valueNode.path)
             kk to vv
           }
         }


### PR DESCRIPTION
## Summary
When a `Map` field is provided as an array of `{key: ..., value: ...}` objects (instead of a nested map), the decoders successfully read the `key` and `value` subnodes but never marked their paths in `context.usedPaths`. Strict mode therefore reported every `key`/`value` subnode as unused even though it was consumed.

The mirror `MapNode` form already did this for the value path (line 39 of `MapDecoder.kt`). This PR applies the same to both subnodes in:
- `hoplite-core/.../MapDecoder.kt::decodeFromArray`
- `hoplite-vavr/.../MapDecoder.kt::decodeFromArray`

Same class of fix as #534 (LinkedHashMap) and the analogous PR for vavr.

## Test plan
- [x] `./gradlew :hoplite-core:test :hoplite-vavr:test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)