### PR TITLE
hoplite-watch: stop FileWatcher spin-looping when the watch service is closed

### DIFF
--- a/hoplite-watch/src/main/kotlin/com/sksamuel/hoplite/watch/watchers/file.kt
+++ b/hoplite-watch/src/main/kotlin/com/sksamuel/hoplite/watch/watchers/file.kt
@@ -1,6 +1,7 @@
 package com.sksamuel.hoplite.watch.watchers
 
 import com.sksamuel.hoplite.watch.Watchable
+import java.nio.file.ClosedWatchServiceException
 import java.nio.file.FileSystems
 import java.nio.file.Paths
 import java.nio.file.StandardWatchEventKinds
@@ -44,6 +45,15 @@ class FileWatcher(private val dir: String) : Watchable {
               break
             }
           }
+        } catch (e: ClosedWatchServiceException) {
+          // The watch service was closed (by us above, or externally). The next take() would
+          // throw again immediately, causing the loop to spin forever invoking errorCallback.
+          // Stop watching instead.
+          break
+        } catch (e: InterruptedException) {
+          // Restore the interrupt status so callers can observe it, then exit the loop.
+          Thread.currentThread().interrupt()
+          break
         } catch (e: Exception) {
           errorCallback(e)
         }

--- a/hoplite-watch/src/main/kotlin/com/sksamuel/hoplite/watch/watchers/file.kt
+++ b/hoplite-watch/src/main/kotlin/com/sksamuel/hoplite/watch/watchers/file.kt
@@ -5,11 +5,20 @@ import java.nio.file.ClosedWatchServiceException
 import java.nio.file.FileSystems
 import java.nio.file.Paths
 import java.nio.file.StandardWatchEventKinds
+import java.nio.file.WatchService
 import java.util.concurrent.Executors
+import java.util.concurrent.Future
 
 class FileWatcher(private val dir: String) : Watchable {
   private var cb = {}
   private var errorCallback: ((Throwable) -> Unit) = { }
+
+  // Visible for testing — lets tests close the watch service externally to drive the
+  // ClosedWatchServiceException path, and join the worker thread to assert it exited cleanly.
+  internal lateinit var watchService: WatchService
+    private set
+  internal lateinit var future: Future<*>
+    private set
 
   override fun watch(callback: () -> Unit, errorHandler: (Throwable) -> Unit) {
     cb = callback
@@ -18,7 +27,7 @@ class FileWatcher(private val dir: String) : Watchable {
   }
 
   private fun start() {
-    val watchService = FileSystems.getDefault().newWatchService()
+    watchService = FileSystems.getDefault().newWatchService()
     // we don't use toRealPath() here, because we *want* to watch the symlinked parent the file is in, not the file's real parent
     val pathToWatch = Paths.get(dir).toAbsolutePath()
 
@@ -29,7 +38,7 @@ class FileWatcher(private val dir: String) : Watchable {
       StandardWatchEventKinds.ENTRY_DELETE
     )
 
-    Executors.newSingleThreadExecutor { Thread(it).apply { isDaemon = true } }.submit {
+    future = Executors.newSingleThreadExecutor { Thread(it).apply { isDaemon = true } }.submit {
       while (true) {
         try {
           val watchKey = watchService.take()

--- a/hoplite-watch/src/test/kotlin/com/sksamuel/hoplite/watch/watchers/FileWatcherSpinLoopTest.kt
+++ b/hoplite-watch/src/test/kotlin/com/sksamuel/hoplite/watch/watchers/FileWatcherSpinLoopTest.kt
@@ -1,0 +1,36 @@
+package com.sksamuel.hoplite.watch.watchers
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.engine.spec.tempdir
+import io.kotest.matchers.comparables.shouldBeLessThanOrEqualTo
+import io.kotest.matchers.shouldBe
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+
+class FileWatcherSpinLoopTest : FunSpec({
+
+  // Regression for #558. Before the fix, FileWatcher's loop caught Exception generically,
+  // invoked errorCallback, and continued. ClosedWatchServiceException is thrown by every
+  // subsequent take() once the service is closed, so the loop spun as fast as the JVM
+  // could run the callback — burning CPU and flooding the user's error handler.
+  test("FileWatcher exits cleanly (no spin) when the watch service is closed externally") {
+    val tmpDir = tempdir()
+    val errorCount = AtomicInteger(0)
+
+    val watcher = FileWatcher(tmpDir.absolutePath)
+    watcher.watch(callback = {}, errorHandler = { errorCount.incrementAndGet() })
+
+    // Close the service externally — that's the trigger for ClosedWatchServiceException.
+    watcher.watchService.close()
+
+    // The worker thread should observe the close on its next take() and break out of the
+    // loop. Give it a moment, then assert the future completes (the worker exited).
+    watcher.future.get(2, TimeUnit.SECONDS)
+    watcher.future.isDone shouldBe true
+
+    // Without the fix, errorCallback would have fired hundreds or thousands of times in
+    // those two seconds. With the fix it should fire at most once (and ideally zero — we
+    // break before invoking it). Allow up to 1 to leave a tiny tolerance for ordering.
+    errorCount.get() shouldBeLessThanOrEqualTo 1
+  }
+})


### PR DESCRIPTION
## Summary
The `FileWatcher` loop catches every `Exception`, invokes `errorCallback`, and keeps going. Two cases that's wrong for:

- `ClosedWatchServiceException`: once the service is closed (by `watchService.close()` above or externally) every subsequent `take()` throws immediately. The loop spins as fast as the JVM can run `errorCallback` — burning CPU and flooding the user with the same error.
- `InterruptedException`: silently swallowed, the interrupt status is cleared, the loop keeps going, defeating cooperative shutdown.

Handle both before the generic `Exception` arm: `break` on closed; restore interrupt status and `break` on interrupt.

## Test plan
- [x] `./gradlew :hoplite-watch:test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)