### PR TITLE
AWS preprocessors: distinguish "secret is not JSON" from "key missing in secret JSON"

### DIFF
--- a/hoplite-aws-kotlin/src/main/kotlin/com/sksamuel/hoplite/aws/kotlin/AwsOps.kt
+++ b/hoplite-aws-kotlin/src/main/kotlin/com/sksamuel/hoplite/aws/kotlin/AwsOps.kt
@@ -56,11 +56,24 @@ class AwsOps(private val client: SecretsManagerClient) {
       if (index == null) {
         secret.valid()
       } else {
-        val map = runCatching { Json.Default.decodeFromString<Map<String, String>>(secret) }.getOrElse { emptyMap() }
-        map[index]?.valid()
-          ?: ConfigFailure.ResolverFailure(
-            "Index '$index' not present in AWS secret '${result.name}'. Present keys are ${map.keys.joinToString(",")}"
-          ).invalid()
+        // Distinguish "secret isn't JSON at all" from "secret is JSON but the index is missing".
+        // The previous code swallowed the parse failure and reported "Index 'X' not present.
+        // Present keys are " (empty), which sent users hunting for a missing key when in fact
+        // their secret was a plain string and didn't support indexing.
+        val parsed = runCatching { Json.Default.decodeFromString<Map<String, String>>(secret) }
+        parsed.fold(
+          { map ->
+            map[index]?.valid()
+              ?: ConfigFailure.ResolverFailure(
+                "Index '$index' not present in AWS secret '${result.name}'. Present keys are ${map.keys.joinToString(",")}"
+              ).invalid()
+          },
+          {
+            ConfigFailure.ResolverFailure(
+              "AWS secret '${result.name}' is not a JSON object — index '$index' cannot be applied"
+            ).invalid()
+          }
+        )
       }
     }
   }

--- a/hoplite-aws-kotlin/src/main/kotlin/com/sksamuel/hoplite/aws/kotlin/AwsSecretsManagerPreprocessor.kt
+++ b/hoplite-aws-kotlin/src/main/kotlin/com/sksamuel/hoplite/aws/kotlin/AwsSecretsManagerPreprocessor.kt
@@ -93,9 +93,17 @@ class AwsSecretsManagerPreprocessor(
             .withMeta(CommonMetadata.RemoteLookup, "AWS '$key'")
             .valid()
         } else {
-          val map = runCatching { json.decodeFromString<Map<String, String>>(secret) }.getOrElse { emptyMap() }
-          val indexedValue = map[index]
-          if (indexedValue == null)
+          // Distinguish "secret isn't JSON at all" from "secret is JSON but the index is missing".
+          // Previously a non-JSON secret was silently treated as an empty map, producing a misleading
+          // "Index 'X' not present. Available keys are " (empty) error.
+          val parsed = runCatching { json.decodeFromString<Map<String, String>>(secret) }
+          val indexedValue = parsed.getOrNull()?.get(index)
+          if (parsed.isFailure)
+            ConfigFailure.PreprocessorWarning(
+              "Secret '$key' in AWS SecretsManager is not a JSON object — index '$index' cannot be applied"
+            ).invalid()
+          else if (indexedValue == null) {
+            val map = parsed.getOrThrow()
             ConfigFailure.PreprocessorWarning(
               "Index '$index' not present in secret '$key'. Available keys are ${
                 map.keys.joinToString(
@@ -103,7 +111,7 @@ class AwsSecretsManagerPreprocessor(
                 )
               }"
             ).invalid()
-          else
+          } else
             node.copy(value = indexedValue)
               .withMeta(CommonMetadata.Secret, true)
               .withMeta(CommonMetadata.UnprocessedValue, node.value)

--- a/hoplite-aws2/src/main/kotlin/com/sksamuel/hoplite/aws2/AwsSecretsManagerPreprocessor.kt
+++ b/hoplite-aws2/src/main/kotlin/com/sksamuel/hoplite/aws2/AwsSecretsManagerPreprocessor.kt
@@ -88,9 +88,17 @@ class AwsSecretsManagerPreprocessor(
             .withMeta(CommonMetadata.RemoteLookup, "AWS '$key'")
             .valid()
         } else {
-          val map = runCatching { json.decodeFromString<Map<String, String>>(secret) }.getOrElse { emptyMap() }
-          val indexedValue = map[index]
-          if (indexedValue == null)
+          // Distinguish "secret isn't JSON at all" from "secret is JSON but the index is missing".
+          // Previously a non-JSON secret was silently treated as an empty map, producing a misleading
+          // "Index 'X' not present. Available keys are " (empty) error.
+          val parsed = runCatching { json.decodeFromString<Map<String, String>>(secret) }
+          val indexedValue = parsed.getOrNull()?.get(index)
+          if (parsed.isFailure)
+            ConfigFailure.PreprocessorWarning(
+              "Secret '$key' in AWS SecretsManager is not a JSON object — index '$index' cannot be applied"
+            ).invalid()
+          else if (indexedValue == null) {
+            val map = parsed.getOrThrow()
             ConfigFailure.PreprocessorWarning(
               "Index '$index' not present in secret '$key'. Available keys are ${
                 map.keys.joinToString(
@@ -98,7 +106,7 @@ class AwsSecretsManagerPreprocessor(
                 )
               }"
             ).invalid()
-          else
+          } else
             node.copy(value = indexedValue)
               .withMeta(CommonMetadata.Secret, true)
               .withMeta(CommonMetadata.UnprocessedValue, node.value)


### PR DESCRIPTION
## Summary
When an AWS secret was indexed (`awssm://secret[key]` or `\${{ aws-secrets-manager:secret[key] }}`) but the secret was **not** a JSON object — e.g. it was stored as a plain string — the decoder silently treated the parse failure as an empty map and reported:

```
Index 'key' not present in secret 'foo'. Available keys are
```

with a trailing empty list. Users would chase a missing key when in fact their secret didn't support indexing at all.

This PR surfaces the parse failure as a distinct error in three places:
- `hoplite-aws-kotlin/.../AwsOps.kt` (used by `AwsSecretsManagerContextResolver`)
- `hoplite-aws-kotlin/.../AwsSecretsManagerPreprocessor.kt`
- `hoplite-aws2/.../AwsSecretsManagerPreprocessor.kt`

The deprecated `hoplite-aws` module has the same pattern but is already flagged for migration to `hoplite-aws2`, so I left it alone.

## Test plan
- [x] `./gradlew :hoplite-aws-kotlin:test :hoplite-aws2:test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)