### PR TITLE
hoplite-watch: route FixedIntervalWatchable callback failures through errorHandler

### DIFF
--- a/hoplite-watch/src/main/kotlin/com/sksamuel/hoplite/watch/Watchable.kt
+++ b/hoplite-watch/src/main/kotlin/com/sksamuel/hoplite/watch/Watchable.kt
@@ -16,7 +16,15 @@ class FixedIntervalWatchable(private val intervalMs: Long) : Watchable {
     GlobalScope.launch {
       while (isActive) {
         delay(intervalMs)
-        callback()
+        // Without this guard, an exception thrown by callback() (or anything it calls
+        // synchronously, like a misbehaving subscriber on the reload path) would propagate up to
+        // the coroutine and silently terminate the watcher, with the user's errorHandler never
+        // invoked. Funnel the failure through errorHandler and keep watching.
+        try {
+          callback()
+        } catch (e: Throwable) {
+          errorHandler(e)
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary
The callback was invoked unguarded inside `GlobalScope.launch`. If `callback()` (or anything it called synchronously — e.g. a misbehaving subscriber on the `ReloadableConfig.update` path) threw, the exception propagated up to the coroutine and **silently terminated the watcher**. The user's `errorHandler` was never invoked, and there was no signal that periodic reloads had stopped.

This PR wraps `callback()` in a `try / catch (Throwable)` that funnels the failure to `errorHandler` and keeps the loop alive.

## Test plan
- [x] `./gradlew :hoplite-watch:test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)