### PR TITLE
Close internal stream wrappers in YAML / JSON / HOCON parsers

### DIFF
--- a/hoplite-hocon/src/main/kotlin/com/sksamuel/hoplite/hocon/HoconParser.kt
+++ b/hoplite-hocon/src/main/kotlin/com/sksamuel/hoplite/hocon/HoconParser.kt
@@ -23,12 +23,17 @@ import java.io.InputStreamReader
 class HoconParser : Parser {
 
   override fun load(input: InputStream, source: String): Node {
-    // Pin the charset to UTF-8. InputStreamReader(input) without a charset uses the JVM
-    // default, which is platform-dependent. HOCON files are UTF-8 by spec
-    // (https://github.com/lightbend/config/blob/main/HOCON.md#unchanged-from-json), so any
-    // non-ASCII content would be misinterpreted on a non-UTF-8 default JVM. Other parsers
-    // (PropsParser) already pin UTF-8 — match that.
-    val config = ConfigFactory.parseReader(InputStreamReader(input, Charsets.UTF_8)).resolve()
+    // Pin the charset to UTF-8: InputStreamReader without a charset uses the platform-default
+    // charset, and HOCON files are UTF-8 by spec
+    // (https://github.com/lightbend/config/blob/main/HOCON.md#unchanged-from-json), so non-ASCII
+    // content would be misinterpreted on a non-UTF-8 default JVM. PropsParser already pins UTF-8.
+    //
+    // Wrap in .use {} so the reader's decoder buffers are released — ConfigFactory.parseReader
+    // does not close it. The caller still owns `input` and may .use {} it independently;
+    // InputStream.close() is idempotent so the double-close is harmless (#532, #533, #539, #540, #551).
+    val config = InputStreamReader(input, Charsets.UTF_8).use { reader ->
+      ConfigFactory.parseReader(reader).resolve()
+    }
     return MapProduction(config.root(), config.origin(), source, DotPath.root)
   }
 

--- a/hoplite-hocon/src/test/kotlin/com/sksamuel/hoplite/hocon/HoconParserStreamCloseTest.kt
+++ b/hoplite-hocon/src/test/kotlin/com/sksamuel/hoplite/hocon/HoconParserStreamCloseTest.kt
@@ -1,0 +1,33 @@
+package com.sksamuel.hoplite.hocon
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import java.io.IOException
+import java.io.InputStream
+
+class HoconParserStreamCloseTest : FunSpec({
+
+  // Regression: HoconParser previously wrapped `input` in InputStreamReader without closing
+  // it (#561). Closing the InputStreamReader closes the underlying stream too — so wrapping
+  // the caller's stream in a tracker and asserting it's closed after load() returns covers
+  // both halves.
+  test("HoconParser closes the underlying input stream after parsing") {
+    val tracker = TrackingInputStream("name = \"hoplite\"\nport = 8080".byteInputStream())
+
+    HoconParser().load(tracker, "test.conf")
+
+    tracker.closed shouldBe true
+  }
+})
+
+private class TrackingInputStream(private val delegate: InputStream) : InputStream() {
+  @Volatile var closed: Boolean = false
+    private set
+  override fun read(): Int = if (closed) throw IOException("Stream closed") else delegate.read()
+  override fun read(b: ByteArray, off: Int, len: Int): Int =
+    if (closed) throw IOException("Stream closed") else delegate.read(b, off, len)
+  override fun close() {
+    closed = true
+    delegate.close()
+  }
+}

--- a/hoplite-json/src/main/kotlin/com/sksamuel/hoplite/json/json.kt
+++ b/hoplite-json/src/main/kotlin/com/sksamuel/hoplite/json/json.kt
@@ -22,9 +22,14 @@ class JsonParser(private val jsonFactory: JsonFactory) : Parser {
   constructor() : this(JsonFactory())
 
   override fun load(input: InputStream, source: String): Node {
-    val parser = jsonFactory.createParser(input).configure(JsonParser.Feature.ALLOW_COMMENTS, true)
-    parser.nextToken()
-    return TokenProduction(parser, source, DotPath.root)
+    // The Jackson parser wraps `input` and holds internal buffers that aren't released until
+    // close() runs. Without `.use {}` every load leaked one parser worth of buffer state and one
+    // reference to the underlying stream. The caller still owns `input` and may .use {} it
+    // independently — InputStream.close() is idempotent, so the double close is harmless.
+    return jsonFactory.createParser(input).configure(JsonParser.Feature.ALLOW_COMMENTS, true).use { parser ->
+      parser.nextToken()
+      TokenProduction(parser, source, DotPath.root)
+    }
   }
 
   override fun defaultFileExtensions(): List<String> = listOf("json")

--- a/hoplite-json/src/test/kotlin/com/sksamuel/hoplite/json/JsonParserStreamCloseTest.kt
+++ b/hoplite-json/src/test/kotlin/com/sksamuel/hoplite/json/JsonParserStreamCloseTest.kt
@@ -1,0 +1,33 @@
+package com.sksamuel.hoplite.json
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import java.io.IOException
+import java.io.InputStream
+
+class JsonParserStreamCloseTest : FunSpec({
+
+  // Regression: JsonParser previously created a Jackson JsonParser around `input` without
+  // closing it (#561). Jackson's parser owns the stream, and closing the parser closes the
+  // underlying stream — so wrapping the caller's stream in a tracker and asserting it's
+  // closed after load() returns covers both halves.
+  test("JsonParser closes the underlying input stream after parsing") {
+    val tracker = TrackingInputStream("""{"name": "hoplite", "port": 8080}""".byteInputStream())
+
+    JsonParser().load(tracker, "test.json")
+
+    tracker.closed shouldBe true
+  }
+})
+
+private class TrackingInputStream(private val delegate: InputStream) : InputStream() {
+  @Volatile var closed: Boolean = false
+    private set
+  override fun read(): Int = if (closed) throw IOException("Stream closed") else delegate.read()
+  override fun read(b: ByteArray, off: Int, len: Int): Int =
+    if (closed) throw IOException("Stream closed") else delegate.read(b, off, len)
+  override fun close() {
+    closed = true
+    delegate.close()
+  }
+}

--- a/hoplite-yaml/src/main/kotlin/com/sksamuel/hoplite/yaml/YamlParser.kt
+++ b/hoplite-yaml/src/main/kotlin/com/sksamuel/hoplite/yaml/YamlParser.kt
@@ -31,27 +31,29 @@ class YamlParser : Parser {
   override fun defaultFileExtensions(): List<String> = listOf("yml", "yaml")
   private val yaml = Yaml()
   override fun load(input: InputStream, source: String): Node {
-    // Pin the charset to UTF-8. InputStreamReader(input) without a charset uses the JVM
-    // default, which is platform-dependent (UTF-8 on most modern systems, historically
-    // Windows-1252 on older Windows JVMs, and changes under -Dfile.encoding overrides).
-    // YAML files are UTF-8 by spec, so non-ASCII content (emoji, accented chars, etc.)
-    // would otherwise be misinterpreted on a non-UTF-8 default JVM. PropsParser already
-    // pins UTF-8 — match that.
-    val reader = InputStreamReader(input, Charsets.UTF_8)
-    val events = yaml.parse(reader).iterator()
-    val stream = TokenStream(events)
-    require(stream.next().`is`(Event.ID.StreamStart)) { "Expected stream start at ${stream.current().startMark}" }
-    return when (stream.next().eventId) {
-      Event.ID.StreamEnd -> Undefined
-      Event.ID.DocumentStart -> {
-        stream.next() // move past the doc start
-        TokenProduction(stream, source, emptyMap(), DotPath.root).first
+    // Pin the charset to UTF-8: InputStreamReader without a charset uses the platform-default
+    // charset (historically Windows-1252 on older Windows JVMs, and changes under -Dfile.encoding).
+    // YAML files are UTF-8 by spec, so non-ASCII content (emoji, accented chars, etc.) would be
+    // misinterpreted on a non-UTF-8 default JVM. PropsParser already pins UTF-8.
+    //
+    // Wrap in .use {} so the reader's decoder buffers are released and close propagates to the
+    // underlying stream. The caller still owns `input`; InputStream.close() is idempotent so the
+    // caller's own .use {} (e.g. #540's ConfigFilePropertySource fix) remains safe.
+    return InputStreamReader(input, Charsets.UTF_8).use { reader ->
+      val events = yaml.parse(reader).iterator()
+      val stream = TokenStream(events)
+      require(stream.next().`is`(Event.ID.StreamStart)) { "Expected stream start at ${stream.current().startMark}" }
+      when (stream.next().eventId) {
+        Event.ID.StreamEnd -> Undefined
+        Event.ID.DocumentStart -> {
+          stream.next() // move past the doc start
+          TokenProduction(stream, source, emptyMap(), DotPath.root).first
+        }
+        // kotlin.error has only one overload — error(message: Any) — so a trailing-lambda call
+        // would pass the lambda itself as the message instead of the text. Use the parenthesised
+        // form so the actual string reaches the user (#553).
+        else -> error("Expected document start at ${stream.current().startMark}")
       }
-      // kotlin.error has only one overload — `error(message: Any)` — so a trailing-lambda call
-      // would pass the lambda itself as the message, and IllegalStateException would be raised
-      // with `message.toString()` of the lambda (something like "Function0<String>") instead of
-      // the intended text. Use the parenthesised form so the actual string reaches the user.
-      else -> error("Expected document start at ${stream.current().startMark}")
     }
   }
 }

--- a/hoplite-yaml/src/test/kotlin/com/sksamuel/hoplite/yaml/YamlParserStreamCloseTest.kt
+++ b/hoplite-yaml/src/test/kotlin/com/sksamuel/hoplite/yaml/YamlParserStreamCloseTest.kt
@@ -1,0 +1,34 @@
+package com.sksamuel.hoplite.yaml
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import java.io.ByteArrayInputStream
+import java.io.IOException
+import java.io.InputStream
+
+class YamlParserStreamCloseTest : FunSpec({
+
+  // Regression: YamlParser previously wrapped `input` in InputStreamReader without closing
+  // it (#561). Closing the InputStreamReader closes the underlying stream too — so wrapping
+  // the caller's stream in a tracker and asserting it's closed after parse() returns covers
+  // both halves.
+  test("YamlParser closes the underlying input stream after parsing") {
+    val tracker = TrackingInputStream("name: hoplite\nport: 8080\n".byteInputStream())
+
+    YamlParser().load(tracker, "test.yaml")
+
+    tracker.closed shouldBe true
+  }
+})
+
+private class TrackingInputStream(private val delegate: InputStream) : InputStream() {
+  @Volatile var closed: Boolean = false
+    private set
+  override fun read(): Int = if (closed) throw IOException("Stream closed") else delegate.read()
+  override fun read(b: ByteArray, off: Int, len: Int): Int =
+    if (closed) throw IOException("Stream closed") else delegate.read(b, off, len)
+  override fun close() {
+    closed = true
+    delegate.close()
+  }
+}


### PR DESCRIPTION
## Summary
Each parser wraps the caller-supplied `InputStream` in a reader / parser that holds buffer state and never closed it:

- `YamlParser`: `InputStreamReader(input)` — leaked on every load.
- `JsonParser`: `jsonFactory.createParser(input)` — leaked Jackson buffers and a stream reference.
- `HoconParser`: `InputStreamReader(input)` — leaked decoder buffers.

Wrap each in `.use {}`. The caller still owns `input` and may close it independently — `InputStream.close()` is idempotent so the double-close is harmless. Pairs with the recent caller-side `.use {}` fixes (#532, #533, #539, #540, #551).

## Test plan
- [x] `./gradlew :hoplite-yaml:test :hoplite-json:test :hoplite-hocon:test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)