### PR TITLE
hoplite-hdfs: catch IllegalArgumentException from Hadoop Path constructor

### DIFF
--- a/hoplite-hdfs/src/main/kotlin/com/sksamuel/hoplite/hdfs/PathDecoder.kt
+++ b/hoplite-hdfs/src/main/kotlin/com/sksamuel/hoplite/hdfs/PathDecoder.kt
@@ -20,7 +20,14 @@ class PathDecoder : NullHandlingDecoder<Path> {
                           type: KType,
                           context: DecoderContext): ConfigResult<Path> {
     return when (node) {
-      is StringNode -> Path(node.value).valid()
+      // Hadoop's Path(String) throws IllegalArgumentException for malformed inputs (e.g. an
+      // empty string or a malformed URI). Without runCatching the exception escaped uncaught
+      // and broke the loader instead of producing a clean ConfigFailure — same class of fix
+      // as #541 for the hoplite-javax security decoders.
+      is StringNode -> runCatching { Path(node.value) }.fold(
+        { it.valid() },
+        { ConfigFailure.DecodeError(node, Path::class.createType()).invalid() }
+      )
       else -> ConfigFailure.DecodeError(node, Path::class.createType()).invalid()
     }
   }


### PR DESCRIPTION
## Summary
`org.apache.hadoop.fs.Path(String)` throws `IllegalArgumentException` for malformed inputs (empty string, malformed URI, etc.). Without `runCatching` the exception escaped uncaught and broke the loader instead of producing a clean `ConfigFailure.DecodeError`.

Same class of fix as #541 for the `hoplite-javax` security decoders.

## Test plan
- [x] `./gradlew :hoplite-hdfs:test` (module has no tests; compile-only verification — fix is mechanical and mirrors #541).

🤖 Generated with [Claude Code](https://claude.com/claude-code)