### PR TITLE
addResourceOrFileSource: stop dropping the leading slash before the file probe

### DIFF
--- a/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/ConfigLoaderBuilderExtensions.kt
+++ b/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/ConfigLoaderBuilderExtensions.kt
@@ -66,16 +66,28 @@ fun ConfigLoaderBuilder.addResourceOrFileSource(
   optional: Boolean = false,
   allowEmpty: Boolean = false,
 ): ConfigLoaderBuilder {
-  val resourceOrFileSanitised = resourceOrFile.removePrefix("/")
-  val path = Paths.get(resourceOrFileSanitised)
-  return if (path.exists()) {
+  // Probe the filesystem with both the verbatim path and the slash-stripped form so that:
+  //  - absolute paths (`/etc/config.yaml`) resolve as files, not as relative-to-CWD that fall
+  //    through to classpath lookup; and
+  //  - `/foo` written as a classpath-style spec still finds a sibling `foo` relative to CWD,
+  //    matching the existing behaviour exercised by SmarterPathAndClasspathLoadingTest.
+  // The classpath fallback uses the slash-stripped form because a leading `/` is meaningless
+  // for ClassLoader.getResourceAsStream.
+  val verbatim = Paths.get(resourceOrFile)
+  val stripped = Paths.get(resourceOrFile.removePrefix("/"))
+  val filesystemPath = when {
+    verbatim.exists() -> verbatim
+    stripped.exists() -> stripped
+    else -> null
+  }
+  return if (filesystemPath != null) {
     addPropertySource(
       ConfigFilePropertySource(
-        ConfigSource.PathSource(path),
+        ConfigSource.PathSource(filesystemPath),
         // Forward the user's `optional` flag. Without this, the file branch silently
         // ignored `optional = true`: if the file existed at probe time but disappeared
         // before load (TOCTOU), the loader threw instead of skipping the source as the
-        // user requested.
+        // user requested. (See #571.)
         optional = optional,
         allowEmpty = allowEmpty
       )
@@ -83,7 +95,7 @@ fun ConfigLoaderBuilder.addResourceOrFileSource(
   } else {
     addPropertySource(
       ConfigFilePropertySource(
-        ConfigSource.ClasspathSource(resourceOrFileSanitised),
+        ConfigSource.ClasspathSource(resourceOrFile.removePrefix("/")),
         optional,
         allowEmpty
       )

--- a/hoplite-core/src/test/kotlin/com/sksamuel/hoplite/gh511/classpathLoadingAndFileLoading/SmarterPathAndClasspathLoadingTest.kt
+++ b/hoplite-core/src/test/kotlin/com/sksamuel/hoplite/gh511/classpathLoadingAndFileLoading/SmarterPathAndClasspathLoadingTest.kt
@@ -6,6 +6,7 @@ import com.sksamuel.hoplite.addResourceOrFileSource
 import com.sksamuel.hoplite.parsers.PropsParser
 import io.kotest.assertions.throwables.shouldNotThrowAny
 import io.kotest.core.spec.style.AnnotationSpec
+import io.kotest.engine.spec.tempdir
 
 class SmarterPathAndClasspathLoadingTest : AnnotationSpec() {
 
@@ -40,6 +41,24 @@ class SmarterPathAndClasspathLoadingTest : AnnotationSpec() {
   @Test
   fun `simple path with slash`() {
     shouldNotThrowAny { loadConfig<Config>(listOf("/.gh511-envfile")) }
+  }
+
+  @Test
+  fun `absolute filesystem path is loaded as a file`() {
+    // Write the same .properties content to an absolute path under tempdir, then load it
+    // by its absolute path. Previously this would silently strip the leading slash and try
+    // to find `tmp/.../foo.properties` relative to CWD, fail, and fall through to a
+    // classpath lookup that didn't exist either.
+    val tempDir = tempdir()
+    val file = tempDir.resolve("absolute.properties")
+    file.writeText(
+      """
+      gh511Database.dbJdbcUrl=jdbc:postgresql://localhost:5432/db
+      gh511Database.username=admin
+      gh511Env=test
+      """.trimIndent()
+    )
+    shouldNotThrowAny { loadConfig<Config>(listOf(file.absolutePath)) }
   }
 
   @OptIn(ExperimentalHoplite::class)


### PR DESCRIPTION
## Summary
`addResourceOrFileSource` called `.removePrefix(\"/\")` on the input **before** probing the filesystem, which silently turned an absolute path like `/etc/config.yaml` into the relative path `etc/config.yaml`. That couldn't be found via `Paths.get(...).exists()` (which resolves relative paths against CWD), so the function fell through to a classpath lookup of `etc/config.yaml` — also generally not found. Net result: a perfectly valid absolute filesystem path was silently unloadable.

This PR probes **both** the verbatim and the slash-stripped form against the filesystem so:
- absolute paths (`/etc/config.yaml`) load as files, and
- the legacy `/foo` → `foo` relative-to-CWD behaviour (locked in by `SmarterPathAndClasspathLoadingTest > simple path with slash`) still works.

The classpath fallback continues to use the slash-stripped form because a leading `/` is meaningless for `ClassLoader.getResourceAsStream`.

## Tests
A new `SmarterPathAndClasspathLoadingTest` case writes a properties file to a tempdir and loads it by absolute path. Verified that it fails against the un-patched extension. All previous cases still pass.

## Test plan
- [x] `./gradlew :hoplite-core:test --tests SmarterPathAndClasspathLoadingTest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)