### PR TITLE
hoplite-aws2: use Locale.ROOT for RegionDecoder case folding

### DIFF
--- a/hoplite-aws2/src/main/kotlin/com/sksamuel/hoplite/aws2/RegionDecoder.kt
+++ b/hoplite-aws2/src/main/kotlin/com/sksamuel/hoplite/aws2/RegionDecoder.kt
@@ -23,7 +23,13 @@ class RegionDecoder : NullHandlingDecoder<Region> {
   ): ConfigResult<Region> {
     fun regionFromName(name: String): ConfigResult<Region> =
       runCatching {
-        Region.regions().single { it.id() == name.lowercase(Locale.getDefault()).replace("_", "-") }
+        // Use Locale.ROOT for the case fold. AWS region IDs are ASCII identifiers
+        // (e.g. "us-east-1") that must compare verbatim against `Region.id()`. Using
+        // Locale.getDefault() means a Turkish-locale machine folds "I" to dotless "ı"
+        // instead of "i" — region names happen not to contain "I" today, but this is
+        // exactly the class of latent bug that bites the day someone does add an I to
+        // an AWS region. Pin to the locale-invariant lower-case algorithm.
+        Region.regions().single { it.id() == name.lowercase(Locale.ROOT).replace("_", "-") }
       }.toValidated { ConfigFailure.Generic("Cannot create region from $name") }
 
     return when (node) {


### PR DESCRIPTION
## Summary
`Region.id()` values are ASCII identifiers like `us-east-1`. Folding the incoming user value with `Locale.getDefault()` means a Turkish-locale machine maps `I` to dotless `ı` instead of `i` — AWS region names happen not to contain `I` today, but this is exactly the class of latent bug that bites the day someone does add one. Pin to `Locale.ROOT` (the locale-invariant algorithm) so the comparison stays correct regardless of where the JVM is running.

## Test plan
- [x] `./gradlew :hoplite-aws2:test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)