### PR TITLE
EnumDecoder: match against Enum.name, not toString()

### DIFF
--- a/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/decoder/enum.kt
+++ b/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/decoder/enum.kt
@@ -28,8 +28,16 @@ class EnumDecoder<T : Any> : NullHandlingDecoder<T> {
     val klass = type.classifier as KClass<*>
     val ignoreCase = context.config.resolveTypesCaseInsensitive
 
+    // Match against the canonical Enum.name, not toString(). The previous code used
+    // it.toString() which works for vanilla Java enums (whose default toString() returns
+    // name) but silently breaks for any enum that overrides toString() — e.g.
+    //
+    //   enum class Color { RED; override fun toString() = "Color::red" }
+    //
+    // would no longer be reachable with `color: RED` because the iterator compared
+    // "Color::red" to "RED". Cast each constant to Enum<*> and use .name.
     fun findConstant(value: String): Any? = klass.java.enumConstants.find {
-      it.toString().contentEquals(other = value, ignoreCase = ignoreCase)
+      (it as Enum<*>).name.contentEquals(other = value, ignoreCase = ignoreCase)
     }
 
     fun decode(value: String): ConfigResult<T> {

--- a/hoplite-core/src/test/kotlin/com/sksamuel/hoplite/decoder/EnumDecoderTest.kt
+++ b/hoplite-core/src/test/kotlin/com/sksamuel/hoplite/decoder/EnumDecoderTest.kt
@@ -93,6 +93,29 @@ class EnumDecoderTest : BehaviorSpec({
       }
     }
   }
+
+  // Regression: previously the decoder matched against Enum.toString(); a custom toString()
+  // (very common when the display form differs from the constant name) would break the lookup.
+  given("an enum class with an overridden toString()") {
+    `when`("the configured value matches the canonical enum name") {
+      val node = StringNode("RED", Pos.NoPos, DotPath.root)
+      val actual = EnumDecoder<EnumWithCustomToString>().decode(node, EnumWithCustomToString::class.createType())
+
+      then("it should still resolve via Enum.name and ignore the custom toString()") {
+        actual.shouldBeInstanceOf<Validated.Valid<EnumWithCustomToString>>()
+          .value shouldBe EnumWithCustomToString.RED
+      }
+    }
+
+    `when`("the configured value matches only the custom toString() (but not the name)") {
+      val node = StringNode("Color::red", Pos.NoPos, DotPath.root)
+      val actual = EnumDecoder<EnumWithCustomToString>().decode(node, EnumWithCustomToString::class.createType())
+
+      then("it should fail — the custom toString() is for display only") {
+        actual.shouldBeInstanceOf<Validated.Invalid<ConfigFailure>>()
+      }
+    }
+  }
 }) {
   private companion object {
     fun <T : Any> EnumDecoder<T>.decode(node: PrimitiveNode, ignoreCase: Boolean) = decode(
@@ -129,6 +152,11 @@ class EnumDecoderTest : BehaviorSpec({
     @ConfigEnumDefault("DoesNotExist")
     enum class TestEnumWithBadDefault {
       Red, Blue
+    }
+
+    enum class EnumWithCustomToString {
+      RED, GREEN, BLUE;
+      override fun toString(): String = "Color::${name.lowercase()}"
     }
   }
 }


### PR DESCRIPTION
## Summary
The lookup compared the candidate value to `it.toString()`. For vanilla Java enums that's harmless because `Enum.toString()` defaults to `name`, but any enum that overrides `toString()` — a very common pattern when the display form differs from the constant name — was suddenly unreachable from config. The decoder was comparing the user's canonical name (e.g. `RED`) to the enum's display string (e.g. `Color::red`) and failing.

```kotlin
enum class Color { RED, GREEN, BLUE; override fun toString() = "Color::${name.lowercase()}" }
```

Cast each constant to `Enum<*>` and compare its `.name`. The existing `ConfigEnumDefault` path already passes a name string, so it remains correct after the switch.

## Tests
Two new regression cases in `EnumDecoderTest` exercise an enum with a non-default `toString()`. Both fail against the un-patched decoder and pass after.

## Test plan
- [x] `./gradlew :hoplite-core:test --tests EnumDecoderTest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)