### PR TITLE
Fix @Deprecated ReplaceWith pointing at the same misspelled method

### DIFF
--- a/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/ConfigLoaderBuilder.kt
+++ b/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/ConfigLoaderBuilder.kt
@@ -370,7 +370,11 @@ class ConfigLoaderBuilder private constructor() {
   @Deprecated("use withReport()", ReplaceWith("withReport()"))
   fun report() = withReport()
 
-  @Deprecated("Use correct spelling", ReplaceWith("withObfusctator(obfuscator)"))
+  // The whole point of this deprecation is to nudge callers off the misspelled name, but the
+  // ReplaceWith hint also pointed at the misspelling, so an IDE quick-fix would silently rewrite
+  // `withObfusctator(x)` to `withObfusctator(x)` — i.e. nothing. Aim it at the correctly-spelled
+  // method instead.
+  @Deprecated("Use correct spelling", ReplaceWith("withObfuscator(obfuscator)"))
   fun withObfusctator(obfuscator: Obfuscator): ConfigLoaderBuilder = withObfuscator(obfuscator)
   fun withObfuscator(obfuscator: Obfuscator): ConfigLoaderBuilder = apply { this.obfuscator = obfuscator }
 


### PR DESCRIPTION
## Summary
`withObfusctator(...)` was deprecated with the message *Use correct spelling*, but the `ReplaceWith` hint named the misspelled function **itself**:

```kotlin
@Deprecated("Use correct spelling", ReplaceWith("withObfusctator(obfuscator)"))
fun withObfusctator(obfuscator: Obfuscator): ConfigLoaderBuilder = withObfuscator(obfuscator)
```

An IDE quick-fix would rewrite `withObfusctator(x)` → `withObfusctator(x)` — i.e. do nothing — defeating the entire point of the deprecation. Point the hint at `withObfuscator` so the quick-fix actually corrects the spelling.

## Test plan
- [x] Compile-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)