### PR TITLE
Close the InputStreamReader in PropsParser

### DIFF
--- a/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/parsers/PropsParser.kt
+++ b/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/parsers/PropsParser.kt
@@ -14,7 +14,10 @@ class PropsParser : Parser {
 
   override fun load(input: InputStream, source: String): Node {
     val props = Properties()
-    props.load(InputStreamReader(input, Charset.forName("UTF-8")))
+    // The reader wraps `input` and must be closed so its decoder buffers are released.
+    // The caller still owns `input` and may close it independently — InputStream.close() is
+    // idempotent so the double-close is harmless.
+    InputStreamReader(input, Charset.forName("UTF-8")).use { reader -> props.load(reader) }
     return props.toNode(source)
   }
 

--- a/hoplite-core/src/test/kotlin/com/sksamuel/hoplite/PropsParserTest.kt
+++ b/hoplite-core/src/test/kotlin/com/sksamuel/hoplite/PropsParserTest.kt
@@ -4,6 +4,8 @@ import com.sksamuel.hoplite.decoder.DotPath
 import com.sksamuel.hoplite.parsers.PropsParser
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
+import java.io.FilterInputStream
+import java.io.InputStream
 
 class PropsParserTest : StringSpec() {
   init {
@@ -49,5 +51,25 @@ class PropsParserTest : StringSpec() {
           DotPath.root
         )
     }
+
+    // Regression: PropsParser used to wrap the caller's InputStream in an InputStreamReader
+    // without closing it, leaking the decoder buffers (and a reference to the underlying
+    // stream) until GC. The reader now lives inside a `.use {}` block, so closing the reader
+    // closes its underlying InputStream too.
+    "load should close the wrapped reader, propagating close() to the underlying input" {
+      val tracking = CloseTrackingInputStream("a.b=c".byteInputStream())
+      PropsParser().load(tracking, source = "a.props")
+      tracking.closeCount shouldBe 1
+    }
+  }
+}
+
+private class CloseTrackingInputStream(delegate: InputStream) : FilterInputStream(delegate) {
+  var closeCount: Int = 0
+    private set
+
+  override fun close() {
+    closeCount++
+    super.close()
   }
 }

--- a/hoplite-core/src/test/kotlin/com/sksamuel/hoplite/parsers/PropsParserStreamCloseTest.kt
+++ b/hoplite-core/src/test/kotlin/com/sksamuel/hoplite/parsers/PropsParserStreamCloseTest.kt
@@ -1,0 +1,34 @@
+package com.sksamuel.hoplite.parsers
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import java.io.IOException
+import java.io.InputStream
+
+class PropsParserStreamCloseTest : FunSpec({
+
+  // Regression for #567. PropsParser previously wrapped `input` in InputStreamReader without
+  // closing it, leaving the decoder buffers (and a reference to the underlying stream) on
+  // the heap until GC. Closing the InputStreamReader closes the underlying stream too — so
+  // wrapping the caller's stream in a tracker and asserting it's closed after load() returns
+  // covers both halves.
+  test("PropsParser closes the underlying input stream after parsing") {
+    val tracker = TrackingInputStream("name=hoplite\nport=8080\n".byteInputStream())
+
+    PropsParser().load(tracker, "test.props")
+
+    tracker.closed shouldBe true
+  }
+})
+
+private class TrackingInputStream(private val delegate: InputStream) : InputStream() {
+  @Volatile var closed: Boolean = false
+    private set
+  override fun read(): Int = if (closed) throw IOException("Stream closed") else delegate.read()
+  override fun read(b: ByteArray, off: Int, len: Int): Int =
+    if (closed) throw IOException("Stream closed") else delegate.read(b, off, len)
+  override fun close() {
+    closed = true
+    delegate.close()
+  }
+}


### PR DESCRIPTION
## Summary
`PropsParser` wrapped the caller's `InputStream` in an `InputStreamReader` and never closed it, leaving the decoder buffers (and a reference to the underlying stream) on the heap until GC. Wrap in `.use {}` like the YAML / JSON / HOCON parsers (see #561). The caller still owns `input` and may close it independently; `InputStream.close()` is idempotent so the double-close is harmless.

## Test plan
- [x] `./gradlew :hoplite-core:test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)