### PR TITLE
hoplite-aws2: AwsSecretsManagerSource null-checks secretString()

### DIFF
--- a/hoplite-aws2/src/main/kotlin/com/sksamuel/hoplite/aws2/AwsSecretsManagerSource.kt
+++ b/hoplite-aws2/src/main/kotlin/com/sksamuel/hoplite/aws2/AwsSecretsManagerSource.kt
@@ -20,7 +20,14 @@ class AwsSecretsManagerSource(
     val secretRequest = GetSecretValueRequest.builder().secretId(key).build()
     val secret = client.getSecretValue(secretRequest)
 
-    return json.decodeFromString<Map<String, String>>(secret.secretString())
+    // GetSecretValueResponse.secretString() returns null when the secret was created with
+    // SecretBinary instead of a string payload. Without this guard the next line would NPE
+    // on a Java platform-type result. Surface a clearer message so the caller knows the
+    // secret was binary and can switch to fetching the binary form.
+    val secretString = secret.secretString()
+      ?: error("AWS secret '$key' has no string value (was it created with SecretBinary?)")
+
+    return json.decodeFromString<Map<String, String>>(secretString)
   }
 
 }

--- a/hoplite-aws2/src/test/kotlin/com/sksamuel/hoplite/aws2/AwsSecretsManagerSourceTest.kt
+++ b/hoplite-aws2/src/test/kotlin/com/sksamuel/hoplite/aws2/AwsSecretsManagerSourceTest.kt
@@ -3,14 +3,17 @@ package com.sksamuel.hoplite.aws2
 import com.sksamuel.hoplite.ConfigLoaderBuilder
 import com.sksamuel.hoplite.addMapSource
 import com.sksamuel.hoplite.parsers.PropsPropertySource
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.extensions.install
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.extensions.testcontainers.ContainerExtension
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
 import kotlinx.serialization.json.Json
 import org.testcontainers.containers.localstack.LocalStackContainer
 import org.testcontainers.utility.DockerImageName
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials
+import software.amazon.awssdk.core.SdkBytes
 import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient
 import java.util.Properties
@@ -65,6 +68,23 @@ class AwsSecretsManagerSourceTest : FunSpec() {
           key1.shouldBe(222)
           key2.shouldBe("override2")
         }
+    }
+
+    // Regression for #568: a secret stored with SecretBinary (no string payload) caused
+    // fetchSecretAsMap to NPE because GetSecretValueResponse.secretString() returns null
+    // (Java platform type) and was passed directly into json.decodeFromString. The fix
+    // surfaces a clear error pointing the user at the binary payload.
+    test("fetchSecretAsMap fails with a clear error when the secret is binary-only") {
+      client.createSecret {
+        it.name("binary-only")
+        it.secretBinary(SdkBytes.fromUtf8String("not a json string"))
+      }
+
+      val ex = shouldThrow<IllegalStateException> {
+        AwsSecretsManagerSource { client }.fetchSecretAsMap("binary-only")
+      }
+      ex.message shouldContain "binary-only"
+      ex.message shouldContain "SecretBinary"
     }
   }
 


### PR DESCRIPTION
## Summary
`GetSecretValueResponse.secretString()` is a Java platform-type method that returns `null` when the secret was stored with `SecretBinary` instead of a string payload. The previous code passed the result straight into `json.decodeFromString`, so the call would NPE rather than producing a useful error.

```kotlin
return json.decodeFromString<Map<String, String>>(secret.secretString())  // NPE if null
```

Surface a clearer message so the caller knows their secret was binary and can switch to the binary fetch path.

## Test plan
- [x] `./gradlew :hoplite-aws2:compileKotlin`

🤖 Generated with [Claude Code](https://claude.com/claude-code)