### PR TITLE
Fix paginated SSM parameter ordering: last page no longer comes first

### DIFF
--- a/hoplite-aws-kotlin/src/main/kotlin/com/sksamuel/hoplite/aws/kotlin/ParameterStorePathPropertySource.kt
+++ b/hoplite-aws-kotlin/src/main/kotlin/com/sksamuel/hoplite/aws/kotlin/ParameterStorePathPropertySource.kt
@@ -46,7 +46,8 @@ class ParameterStorePathPropertySource(
           nextToken = result.nextToken
         }
         go(nextReq, (parameters + resultParams).toMutableList())
-      } else resultParams + parameters
+      } else parameters + resultParams // append the final page after the accumulator,
+      // not before it — the previous order put the last page at the front of the list.
     }
     go(req, params)
   }

--- a/hoplite-aws/src/main/kotlin/com/sksamuel/hoplite/aws/ParameterStorePathPropertySource.kt
+++ b/hoplite-aws/src/main/kotlin/com/sksamuel/hoplite/aws/ParameterStorePathPropertySource.kt
@@ -39,7 +39,8 @@ class ParameterStorePathPropertySource(
       return if (result.nextToken != null) {
         request.nextToken = result.nextToken
         go(request, (parameters + result.parameters).toMutableList())
-      } else result.parameters + parameters
+      } else parameters + result.parameters // append the final page after the accumulator,
+      // not before it — the previous order put the last page at the front of the list.
     }
     go(req, params)
   }


### PR DESCRIPTION
## Summary
The pagination tail-recursion in `ParameterStorePathPropertySource` (both `hoplite-aws` and `hoplite-aws-kotlin`) accumulated pages 1..n-1 into `parameters` correctly, but the base case computed `result.parameters + parameters` — putting the **final page in front of everything that came before**. A path that paginated across three pages came back in the order `[page3, page1, page2]` instead of `[page1, page2, page3]`.

For most callers that's "just" cosmetic (the keys still resolve), but
- order-sensitive callers (snapshot tests, hashed manifests) saw a different result every time they crossed a page boundary;
- if a path ever held duplicate names (rare but possible after a rename), the apparent precedence was reversed.

Swap to `parameters + result.parameters` in both modules so the returned list reads top-to-bottom in fetch order. Mirrors the pagination work for the companion preprocessor in #552.

## Test plan
- [x] Compile-only — neither module has paginated-source integration tests, but the fix is mechanical and the order is the only thing changing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)