### PR TITLE
addResourceOrFileSource: forward the optional flag in the filesystem branch

### DIFF
--- a/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/ConfigLoaderBuilderExtensions.kt
+++ b/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/ConfigLoaderBuilderExtensions.kt
@@ -72,6 +72,11 @@ fun ConfigLoaderBuilder.addResourceOrFileSource(
     addPropertySource(
       ConfigFilePropertySource(
         ConfigSource.PathSource(path),
+        // Forward the user's `optional` flag. Without this, the file branch silently
+        // ignored `optional = true`: if the file existed at probe time but disappeared
+        // before load (TOCTOU), the loader threw instead of skipping the source as the
+        // user requested.
+        optional = optional,
         allowEmpty = allowEmpty
       )
     )


### PR DESCRIPTION
## Summary
The function accepts an `optional` parameter that controls *"if the source goes missing, skip it instead of erroring"*. The classpath branch correctly forwarded it, but the filesystem branch passed `ConfigFilePropertySource(PathSource(path), allowEmpty = ...)` and let `optional` default to `false`. If the file existed at probe time but disappeared before load (TOCTOU window during reload, file watch, etc.), the loader threw an `UnknownPath` error instead of silently skipping the source as the user explicitly requested.

Pass it through.

Independent of #563 (which fixes a different bug in the same function: the slash-stripping that broke absolute paths).

## Test plan
- [x] `./gradlew :hoplite-core:test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)