### PR TITLE
docs: addPathSource and PropertySource.path read from the filesystem, not classpath

### DIFF
--- a/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/ConfigLoaderBuilderExtensions.kt
+++ b/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/ConfigLoaderBuilderExtensions.kt
@@ -42,10 +42,11 @@ fun ConfigLoaderBuilder.addFileSource(
 ) = addPathSource(file.toPath(), optional, allowEmpty)
 
 /**
- * Adds a [PropertySource] that will read the specified resource from the classpath.
+ * Adds a [PropertySource] that will read the file at the given filesystem [Path].
+ * (Not a classpath resource — use [addResourceSource] for that.)
  *
- * @param path the [Path] of the resource to be read
- * @param optional if true, the config loader will ignore this source if the resource does not exist
+ * @param path the filesystem [Path] to be read
+ * @param optional if true, the config loader will ignore this source if the file does not exist
  */
 fun ConfigLoaderBuilder.addPathSource(
   path: Path,

--- a/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/PropertySource.kt
+++ b/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/PropertySource.kt
@@ -59,9 +59,10 @@ interface PropertySource {
       path(file.toPath(), optional, allowEmpty)
 
     /**
-     * Returns a [PropertySource] that will read the specified resource from the classpath.
+     * Returns a [PropertySource] that will read the file at the given filesystem [Path].
+     * (Not a classpath resource — use [resource] for that.)
      *
-     * @param optional if true then the resource can not exist and the config loader will ignore this source
+     * @param optional if true then the file can not exist and the config loader will ignore this source
      */
     fun path(path: Path, optional: Boolean = false, allowEmpty: Boolean = false) =
       ConfigFilePropertySource(ConfigSource.PathSource(path), optional = optional, allowEmpty = allowEmpty)


### PR DESCRIPTION
## Summary
Both docstrings on the `Path`-typed file sources said *"will read the specified resource from the classpath"* — almost certainly copy-paste from `addResourceSource` / `PropertySource.resource`. They actually wrap `ConfigSource.PathSource`, which loads from the local filesystem, so the docs sent users in the wrong direction (and IDE quick-import suggestions would land on the wrong function).

Rewrite both to say "the file at the given filesystem `Path`" and cross-reference the actual classpath function.

## Test plan
- [x] No code changes — docstrings only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)