### PR TITLE
hoplite-yaml / hoplite-hocon: pin reader charset to UTF-8

### DIFF
--- a/hoplite-hocon/src/main/kotlin/com/sksamuel/hoplite/hocon/HoconParser.kt
+++ b/hoplite-hocon/src/main/kotlin/com/sksamuel/hoplite/hocon/HoconParser.kt
@@ -23,7 +23,12 @@ import java.io.InputStreamReader
 class HoconParser : Parser {
 
   override fun load(input: InputStream, source: String): Node {
-    val config = ConfigFactory.parseReader(InputStreamReader(input)).resolve()
+    // Pin the charset to UTF-8. InputStreamReader(input) without a charset uses the JVM
+    // default, which is platform-dependent. HOCON files are UTF-8 by spec
+    // (https://github.com/lightbend/config/blob/main/HOCON.md#unchanged-from-json), so any
+    // non-ASCII content would be misinterpreted on a non-UTF-8 default JVM. Other parsers
+    // (PropsParser) already pin UTF-8 — match that.
+    val config = ConfigFactory.parseReader(InputStreamReader(input, Charsets.UTF_8)).resolve()
     return MapProduction(config.root(), config.origin(), source, DotPath.root)
   }
 

--- a/hoplite-yaml/src/main/kotlin/com/sksamuel/hoplite/yaml/YamlParser.kt
+++ b/hoplite-yaml/src/main/kotlin/com/sksamuel/hoplite/yaml/YamlParser.kt
@@ -31,7 +31,13 @@ class YamlParser : Parser {
   override fun defaultFileExtensions(): List<String> = listOf("yml", "yaml")
   private val yaml = Yaml()
   override fun load(input: InputStream, source: String): Node {
-    val reader = InputStreamReader(input)
+    // Pin the charset to UTF-8. InputStreamReader(input) without a charset uses the JVM
+    // default, which is platform-dependent (UTF-8 on most modern systems, historically
+    // Windows-1252 on older Windows JVMs, and changes under -Dfile.encoding overrides).
+    // YAML files are UTF-8 by spec, so non-ASCII content (emoji, accented chars, etc.)
+    // would otherwise be misinterpreted on a non-UTF-8 default JVM. PropsParser already
+    // pins UTF-8 — match that.
+    val reader = InputStreamReader(input, Charsets.UTF_8)
     val events = yaml.parse(reader).iterator()
     val stream = TokenStream(events)
     require(stream.next().`is`(Event.ID.StreamStart)) { "Expected stream start at ${stream.current().startMark}" }


### PR DESCRIPTION
## Summary
`YamlParser` and `HoconParser` wrapped the `InputStream` in `InputStreamReader(input)` **without a charset**, so they used the JVM default — UTF-8 on most modern systems but historically Windows-1252 on older Windows JVMs and arbitrary under `-Dfile.encoding` overrides.

Both YAML and HOCON specs require UTF-8, so any non-ASCII content (emoji, accented chars, BOM-less unicode) would silently mis-decode on a non-UTF-8 default JVM. `PropsParser` already pins UTF-8 — bring these two in line.

## Test plan
- [x] `./gradlew :hoplite-yaml:test :hoplite-hocon:test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)