### PR TITLE
Lower-case file extensions so the parser registry lookup is case-insensitive

### DIFF
--- a/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/ConfigSource.kt
+++ b/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/ConfigSource.kt
@@ -39,7 +39,10 @@ abstract class ConfigSource {
     //  From my summary look, i think this  will take a little more work though than just this little PR,
     //    so I'd like to ask if this makes sense to you as well?
     override fun describe(): String = path.toString()
-    override fun ext() = path.fileName.toString().split('.').last()
+    // Lower-case the extension so the parser registry lookup is case-insensitive — file names
+    // like `application.YAML` (common on Windows / case-insensitive filesystems) would
+    // otherwise miss the registered "yaml" parser and fail with NoSuchParser.
+    override fun ext() = path.fileName.toString().substringAfterLast('.').lowercase()
     override fun open(optional: Boolean): ConfigResult<InputStream?> {
       return when {
         path.exists() -> runCatching { Files.newInputStream(path) }.toValidated { ConfigFailure.ErrorOpeningPath(path) }
@@ -54,7 +57,9 @@ abstract class ConfigSource {
     private val classpathResourceLoader: ClasspathResourceLoader = Companion::class.java.toClasspathResourceLoader()
   ) : ConfigSource() {
     override fun describe(): String = "classpath:$resource"
-    override fun ext() = resource.split('.').last()
+    // Lower-case for the same reason as PathSource.ext — the parser registry stores extensions
+    // in their lower-case canonical form.
+    override fun ext() = resource.substringAfterLast('.').lowercase()
     override fun open(optional: Boolean): ConfigResult<InputStream?> {
       val input = classpathResourceLoader.getResourceAsStream(resource)
       return when {

--- a/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/sources/XdgConfigPropertySource.kt
+++ b/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/sources/XdgConfigPropertySource.kt
@@ -37,7 +37,9 @@ object XdgConfigPropertySource : PropertySource {
     }
     return if (path == null) Undefined.valid() else {
       val input = path.inputStream()
-      context.parsers.locate(path.extension).map {
+      // Lower-case so an XDG config like `hoplite.YAML` still hits the registered "yaml"
+      // parser (matches ConfigSource.PathSource.ext()).
+      context.parsers.locate(path.extension.lowercase()).map {
         it.load(input, path.toString())
       }
     }


### PR DESCRIPTION
## Summary
`ConfigSource.ext()` returned the file's extension verbatim and handed it to the parser registry, which keys parsers by exact lowercase strings (`PropsParser` registers `"props"`/`"properties"`, `YamlParser` registers `"yml"`/`"yaml"`, etc.). A file named `application.YAML` — common on Windows / case-insensitive filesystems, or a user typo — yielded extension `"YAML"`, missed every registered parser, and failed with `NoSuchParser` even though `hoplite-yaml` was on the classpath.

Lower-case the extension on the way out of:
- `ConfigSource.PathSource.ext()`
- `ConfigSource.ClasspathSource.ext()`
- `XdgConfigPropertySource` (which used `path.extension` directly)

Also switch from `split('.').last()` to the equivalent `substringAfterLast('.')` for clarity.

## Test plan
- [x] `./gradlew :hoplite-core:test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)