### PR TITLE
Fix typo in cascade error message: "overriden" -> "overridden"

### DIFF
--- a/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/ConfigFailure.kt
+++ b/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/ConfigFailure.kt
@@ -38,7 +38,7 @@ sealed interface ConfigFailure {
   data class OverrideConfigError(val overrides: List<OverridePath>) : ConfigFailure {
     override fun description(): String {
       val keys = overrides.joinToString("\n") {
-        " - " + it.path.flatten() + " at ${it.overridePos.loc()} overriden by ${it.overridenPos.loc()}"
+        " - " + it.path.flatten() + " at ${it.overridePos.loc()} overridden by ${it.overridenPos.loc()}"
       }
       return "Overridden configs are configured as errors\n$keys"
     }

--- a/hoplite-core/src/test/kotlin/com/sksamuel/hoplite/CascadeTest.kt
+++ b/hoplite-core/src/test/kotlin/com/sksamuel/hoplite/CascadeTest.kt
@@ -205,7 +205,7 @@ class CascadeTest : FunSpec({
     }.message shouldBe "Error loading config because:\n" +
       "\n" +
       "    Overridden configs are configured as errors\n" +
-      "     - database.port at (props string source) overriden by (props string source)\n" +
-      "     - database.tls at (props string source) overriden by (props string source)"
+      "     - database.port at (props string source) overridden by (props string source)\n" +
+      "     - database.tls at (props string source) overridden by (props string source)"
   }
 })


### PR DESCRIPTION
## Summary
The `CascadeMode.Error` failure message read:

```
- database.port at (...) overriden by (...)
```

with one `d`. Surfaces in test output, logs, and any user-facing report. Add the missing letter.

The internal field name `OverridePath.overridenPos` carries the same typo but renaming it would be a public-API break (`OverridePath` is exposed via `ConfigFailure.OverrideConfigError.overrides: List<OverridePath>`), so leave the field name and only fix the rendered string.

## Test plan
- [x] `./gradlew :hoplite-core:test --tests CascadeTest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)