### PR TITLE
SealedClassDecoder: align deriveInstance object lookup with java.simpleName

### DIFF
--- a/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/decoder/SealedClassDecoder.kt
+++ b/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/decoder/SealedClassDecoder.kt
@@ -100,9 +100,15 @@ class SealedClassDecoder : NullHandlingDecoder<Any> {
       else -> {
 
         // if we have a string node and that string is the name of an object instance,
-        // we can use the object directly
+        // we can use the object directly. Use `.java.simpleName` so this branch matches the
+        // other two name-based lookups in this file (the discriminator paths on lines 61 and
+        // 67) and the `${available subclasses…}` error rendered by
+        // ConfigFailure.NoSealedClassObjectSubtype — KClass.simpleName and Class.simpleName
+        // happen to agree for typical nested sealed subclasses but disagree for anonymous /
+        // local classes, and the inconsistency means users could see error text listing names
+        // that the decoder won't actually accept.
         val error = if (node is StringNode) {
-          val obj = subclasses.find { it.simpleName == node.value }?.objectInstance
+          val obj = subclasses.find { it.java.simpleName == node.value }?.objectInstance
           if (obj != null) return obj.valid() else ConfigFailure.NoSealedClassObjectSubtype(kclass, node.value)
         } else null
 


### PR DESCRIPTION
## Summary
The other two object-instance lookups in this file (lines 61 and 67, the explicit-discriminator paths) use `it.java.simpleName`, and the *"available subclasses"* error rendered by `ConfigFailure.NoSealedClassObjectSubtype` also uses `it.java.simpleName`. The `deriveInstance` branch on line 105 used `KClass.simpleName` instead.

For typical nested sealed subclasses these two names agree, but they disagree for anonymous/local classes (`KClass.simpleName` returns `null`, `Class.simpleName` returns `""` or a generated name). The mismatch meant users could be shown error text listing names that the decoder wouldn't actually accept.

Switch to `.java.simpleName` so the lookup and the error message agree.

## Test plan
- [x] `./gradlew :hoplite-core:test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)