### PR TITLE
SealedClassDecoder: don't crash when no sealed subtype matches the node

### DIFF
--- a/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/decoder/SealedClassDecoder.kt
+++ b/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/decoder/SealedClassDecoder.kt
@@ -6,6 +6,7 @@ import com.sksamuel.hoplite.DecoderContext
 import com.sksamuel.hoplite.MapNode
 import com.sksamuel.hoplite.Node
 import com.sksamuel.hoplite.StringNode
+import com.sksamuel.hoplite.fp.NonEmptyList
 import com.sksamuel.hoplite.fp.Validated
 import com.sksamuel.hoplite.fp.invalid
 import com.sksamuel.hoplite.fp.plus
@@ -122,8 +123,22 @@ class SealedClassDecoder : NullHandlingDecoder<Any> {
         val success = results.firstOrNull { it.isValid() }
         if (success != null) return success
 
-        val errors = results.sequence().getInvalidUnsafe() + listOfNotNull(error)
-        return ConfigFailure.SealedClassSubtypeFailure(kclass, node, errors).invalid()
+        // `results` may be empty if every subclass requires more mandatory constructor
+        // arguments than the supplied node provides — `hasConstructorsWithArgumentsNumberLessOrEqualTo`
+        // filtered them all out. In that case `results.sequence()` was `Valid(emptyList)`,
+        // and the previous `getInvalidUnsafe()` call crashed with IllegalStateException
+        // ("Not an invalid instance"). Pull errors out via filter and synthesise a generic
+        // failure when there's nothing else to report so the user sees a clean diagnostic
+        // instead of an unrelated stack trace.
+        val resultErrors = results.filterIsInstance<Validated.Invalid<ConfigFailure>>().map { it.error }
+        val errors: List<ConfigFailure> = resultErrors + listOfNotNull(error)
+        val nelErrors = if (errors.isEmpty())
+          NonEmptyList.of<ConfigFailure>(
+            ConfigFailure.Generic("No sealed subtype of ${kclass.qualifiedName} could match the supplied config")
+          )
+        else
+          NonEmptyList.unsafe(errors)
+        return ConfigFailure.SealedClassSubtypeFailure(kclass, node, nelErrors).invalid()
       }
     }
   }

--- a/hoplite-core/src/test/kotlin/com/sksamuel/hoplite/decoder/SealedClassDecoderEmptyResultsTest.kt
+++ b/hoplite-core/src/test/kotlin/com/sksamuel/hoplite/decoder/SealedClassDecoderEmptyResultsTest.kt
@@ -1,0 +1,44 @@
+package com.sksamuel.hoplite.decoder
+
+import com.sksamuel.hoplite.ConfigException
+import com.sksamuel.hoplite.ConfigLoaderBuilder
+import com.sksamuel.hoplite.MapNode
+import com.sksamuel.hoplite.Pos
+import com.sksamuel.hoplite.PropertySource
+import com.sksamuel.hoplite.StringNode
+import com.sksamuel.hoplite.addMapSource
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
+
+class SealedClassDecoderEmptyResultsTest : FunSpec({
+
+  // Regression: deriveInstance previously called `results.sequence().getInvalidUnsafe()` after
+  // filtering out subclasses whose mandatory-arg count exceeded the supplied node's size. If
+  // the filter dropped *every* subclass (e.g. node has one field but every subclass needs two
+  // mandatory args), `results` was empty, `sequence()` returned `Valid(emptyList)`, and
+  // `getInvalidUnsafe()` threw IllegalStateException("Not an invalid instance...") — leaking
+  // an internal stack trace instead of a clean SealedClassSubtypeFailure.
+  test("undecodable sealed config produces a clean failure, not IllegalStateException") {
+    val ex = shouldThrow<ConfigException> {
+      ConfigLoaderBuilder.defaultWithoutPropertySources()
+        // single-field map can't satisfy any of the two-mandatory-arg subclasses
+        .addMapSource(mapOf("animal" to mapOf("name" to "Whiskers")))
+        .build()
+        .loadConfigOrThrow<Holder>()
+    }
+
+    // Before the fix: message contained "Not an invalid instance" or similar IllegalStateException text.
+    ex.message.orEmpty() shouldNotContain "Not an invalid instance"
+    // After the fix: a recognisable sealed-class failure mentioning the type.
+    ex.message.orEmpty() shouldContain "Animal"
+  }
+}) {
+  sealed interface Animal {
+    data class Cat(val name: String, val age: Int) : Animal
+    data class Dog(val breed: String, val owner: String) : Animal
+  }
+
+  data class Holder(val animal: Animal)
+}


### PR DESCRIPTION
## Summary
`deriveInstance` computed `results.sequence().getInvalidUnsafe()` even when `results` was empty. The empty case is reachable: every subclass is filtered out by `hasConstructorsWithArgumentsNumberLessOrEqualTo` when the supplied node has fewer fields than every subclass needs as mandatory constructor args. For example:

```kotlin
sealed interface Animal {
  data class Cat(val name: String, val age: Int) : Animal
  data class Dog(val breed: String, val owner: String) : Animal
}
```

with config `animal: { name: "Whiskers" }` (one field, all subclasses need two mandatory args) filtered everything out. `results` was empty, `sequence()` returned `Valid(emptyList)`, and `getInvalidUnsafe()` threw `IllegalStateException("Not an invalid instance...")` — a confusing internal stack trace instead of a user-facing diagnostic.

Pull errors out via `filterIsInstance<Validated.Invalid>` and synthesise a generic `ConfigFailure` when `results` was empty so the user gets a clean `SealedClassSubtypeFailure` mentioning the type.

## Tests
A regression test in `SealedClassDecoderEmptyResultsTest` exercises the empty-results case. Verified it fails against the un-patched decoder.

## Test plan
- [x] `./gradlew :hoplite-core:test --tests SealedClassDecoderEmptyResultsTest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)