### PR TITLE
IntDecoder/ByteDecoder/ShortDecoder: range-check LongNode instead of silently truncating

### DIFF
--- a/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/decoder/primitives.kt
+++ b/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/decoder/primitives.kt
@@ -107,7 +107,14 @@ class IntDecoder : NonNullableLeafDecoder<Int> {
       }
     }
     is DoubleNode -> node.value.toInt().valid()
-    is LongNode -> node.value.toInt().valid()
+    // Long.toInt() silently truncates when the value is outside Int range — e.g. a JSON
+    // integer literal of 3_000_000_000 would arrive as a LongNode and decode to a negative
+    // Int. The String path uses toInt() which throws NumberFormatException on overflow, so
+    // those callers got a clean error; the LongNode path didn't. Range-check up front.
+    is LongNode -> if (node.value in Int.MIN_VALUE..Int.MAX_VALUE)
+      node.value.toInt().valid()
+    else
+      ConfigFailure.NumberConversionError(node, type).invalid()
     else -> ConfigFailure.DecodeError(node, type).invalid()
   }
 }
@@ -126,7 +133,11 @@ class ByteDecoder : NonNullableLeafDecoder<Byte> {
       }
     }
     is DoubleNode -> runCatching { node.value.toInt().toByte() }.toValidated { ThrowableFailure(it) }
-    is LongNode -> node.value.toByte().valid()
+    // Same overflow trap as IntDecoder: LongNode(1000) silently produced a Byte of -24.
+    is LongNode -> if (node.value in Byte.MIN_VALUE..Byte.MAX_VALUE)
+      node.value.toByte().valid()
+    else
+      ConfigFailure.NumberConversionError(node, type).invalid()
     else -> ConfigFailure.DecodeError(node, type).invalid()
   }
 }
@@ -139,7 +150,11 @@ class ShortDecoder : NonNullableLeafDecoder<Short> {
     context: DecoderContext
   ): ConfigResult<Short> = when (node) {
     is StringNode -> runCatching { node.value.toShort() }.toValidated { ThrowableFailure(it) }
-    is LongNode -> node.value.toShort().valid()
+    // Same overflow trap as IntDecoder.
+    is LongNode -> if (node.value in Short.MIN_VALUE..Short.MAX_VALUE)
+      node.value.toShort().valid()
+    else
+      ConfigFailure.NumberConversionError(node, type).invalid()
     else -> ConfigFailure.DecodeError(node, type).invalid()
   }
 }

--- a/hoplite-core/src/test/kotlin/com/sksamuel/hoplite/decoder/IntegerOverflowTest.kt
+++ b/hoplite-core/src/test/kotlin/com/sksamuel/hoplite/decoder/IntegerOverflowTest.kt
@@ -1,0 +1,59 @@
+package com.sksamuel.hoplite.decoder
+
+import com.sksamuel.hoplite.ConfigFailure
+import com.sksamuel.hoplite.DecoderConfig
+import com.sksamuel.hoplite.DecoderContext
+import com.sksamuel.hoplite.LongNode
+import com.sksamuel.hoplite.Pos
+import com.sksamuel.hoplite.defaultNodeTransformers
+import com.sksamuel.hoplite.defaultParamMappers
+import com.sksamuel.hoplite.fp.Validated
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlin.reflect.full.createType
+
+class IntegerOverflowTest : FunSpec({
+
+  // Regression: LongNode -> IntDecoder used Long.toInt(), which silently truncates a Long
+  // outside Int range. JSON/YAML/HOCON can produce a LongNode for any integer literal that
+  // doesn't fit in 32 bits, so this path is reachable in real configs (a numeric literal of
+  // 3_000_000_000 would arrive as a LongNode and decode to a negative Int). The String path
+  // already threw NumberFormatException for the same input — so the LongNode path was the
+  // only one that was lossy.
+  fun ctx() = DecoderContext(
+    decoders = defaultDecoderRegistry(),
+    paramMappers = defaultParamMappers(),
+    nodeTransformers = defaultNodeTransformers(),
+    config = DecoderConfig(flattenArraysToString = false, resolveTypesCaseInsensitive = false),
+  )
+
+  test("IntDecoder on a LongNode larger than Int.MAX_VALUE returns Invalid, not a truncated Int") {
+    val node = LongNode(3_000_000_000L, Pos.NoPos, DotPath.root)
+    val result = IntDecoder().decode(node, Int::class.createType(), ctx())
+    result.shouldBeInstanceOf<Validated.Invalid<ConfigFailure>>()
+  }
+
+  test("IntDecoder on a LongNode smaller than Int.MIN_VALUE returns Invalid, not a truncated Int") {
+    val node = LongNode(-3_000_000_000L, Pos.NoPos, DotPath.root)
+    val result = IntDecoder().decode(node, Int::class.createType(), ctx())
+    result.shouldBeInstanceOf<Validated.Invalid<ConfigFailure>>()
+  }
+
+  test("ShortDecoder on a LongNode larger than Short.MAX_VALUE returns Invalid, not a truncated Short") {
+    val node = LongNode(100_000L, Pos.NoPos, DotPath.root)
+    val result = ShortDecoder().decode(node, Short::class.createType(), ctx())
+    result.shouldBeInstanceOf<Validated.Invalid<ConfigFailure>>()
+  }
+
+  test("ByteDecoder on a LongNode larger than Byte.MAX_VALUE returns Invalid, not a truncated Byte") {
+    val node = LongNode(1000L, Pos.NoPos, DotPath.root)
+    val result = ByteDecoder().decode(node, Byte::class.createType(), ctx())
+    result.shouldBeInstanceOf<Validated.Invalid<ConfigFailure>>()
+  }
+
+  test("IntDecoder on a LongNode that does fit decodes successfully") {
+    val node = LongNode(42L, Pos.NoPos, DotPath.root)
+    val result = IntDecoder().decode(node, Int::class.createType(), ctx())
+    result.shouldBeInstanceOf<Validated.Valid<Int>>()
+  }
+})


### PR DESCRIPTION
## Summary
`Long.toInt` / `.toShort` / `.toByte` silently truncate when the source `Long` falls outside the destination type's range. JSON, YAML, and HOCON all emit `LongNode` for any integer literal that fits in 64 bits, so a config value of `3_000_000_000` (or `100_000` for `Short`, or `1000` for `Byte`) quietly decoded to a wrong, often negative number — and the caller had no clue.

The `String` code path already threw `NumberFormatException` for the same input, so two configs that should have decoded identically didn't:

```yaml
# Both decode to the same Int — except they didn't:
n_string: "3000000000"   # String path: ConfigFailure.NumberConversionError ✓
n_long: 3000000000       # LongNode path: silently became -1294967296 ❌
```

Range-check before converting and return `ConfigFailure.NumberConversionError` when the value won't fit.

## Tests
Five tests in `IntegerOverflowTest` exercise the LongNode-overflow paths against `IntDecoder`, `ShortDecoder`, `ByteDecoder` (plus a positive case to confirm normal values still work). All four overflow tests fail against the un-patched decoders.

## Test plan
- [x] `./gradlew :hoplite-core:test --tests IntegerOverflowTest`
- [x] `./gradlew :hoplite-core:test` (no other regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)