### PR TITLE
Fix typos and one wrong-verb docstring

### DIFF
--- a/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/ConfigSource.kt
+++ b/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/ConfigSource.kt
@@ -70,7 +70,7 @@ abstract class ConfigSource {
     /**
      * If this [resourceOrFile] is located in the classpath returns a [ConfigSource.ClasspathSource],
      * otherwise if this [resourceOrFile] is located in the filesystem returns a [ConfigSource.PathSource].
-     * If the resource is neither on the classpath nor the fileystem, returns a [ConfigFailure].
+     * If the resource is neither on the classpath nor the filesystem, returns a [ConfigFailure].
      */
     fun fromResourcesOrFiles(
       resourceOrFile: String,
@@ -92,7 +92,7 @@ abstract class ConfigSource {
      * For each [resourceOrFiles], if they  are located in the classpath, then a [ConfigSource.ClasspathSource]
      * is returned, otherwise a [ConfigSource.PathSource] is returned.
      *
-     * If the resource is neither on the classpath nor the fileystem, returns a [ConfigFailure].
+     * If the resource is neither on the classpath nor the filesystem, returns a [ConfigFailure].
      */
     fun fromResourcesOrFiles(
       resourceOrFiles: List<String>,

--- a/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/DecoderContext.kt
+++ b/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/DecoderContext.kt
@@ -25,7 +25,7 @@ data class DecoderContext(
   val paramMappers: List<ParameterMapper>,
   val nodeTransformers: List<NodeTransformer>,
   val reporter: Reporter = Reporter(),
-  // these are the dot paths for every config value - overrided or not, that was used
+  // these are the dot paths for every config value - overridden or not, that was used
   val usedPaths: MutableSet<DotPath> = mutableSetOf(),
   // this tracks the types that a node was marshalled into
   val used: MutableMap<DotPath, NodeState> = mutableMapOf(),
@@ -50,7 +50,7 @@ data class DecoderContext(
   fun decoder(type: KParameter): Validated<ConfigFailure, Decoder<*>> = decoder(type.type)
 
   /**
-   * Makes a node as marshalled into the given [type] with the resolved value [value].
+   * Marks a node as marshalled into the given [type] with the resolved value [value].
    */
   fun used(node: Node, type: KType, value: Any?) {
     this.used[node.path] = NodeState(node, true, value, type)

--- a/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/Pos.kt
+++ b/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/Pos.kt
@@ -21,7 +21,7 @@ sealed class Pos {
   data class LinePos(val line: Int, val source: String) : Pos()
 
   /**
-   * Used when we know the filename, line and columnn.
+   * Used when we know the filename, line and column.
    */
   data class LineColPos(val line: Int, val col: Int, val source: String) : Pos()
 

--- a/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/internal/cascade.kt
+++ b/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/internal/cascade.kt
@@ -36,7 +36,7 @@ class Cascader(
 
   /**
    * Returns a new [Node] which is the result of merging node a with node b,
-   * with keys in node a taking preccence if they are defined and not null.
+   * with keys in node a taking precedence if they are defined and not null.
    *
    * @return a [CascadeResult] containing the resolved [Node], and a list of overrides.
    */

--- a/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/nodes.kt
+++ b/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/nodes.kt
@@ -84,7 +84,7 @@ object CommonMetadata {
 }
 
 /**
- * Returnes true if this node is not [Undefined]
+ * Returns true if this node is not [Undefined]
  */
 val Node.isDefined: Boolean
   get() = this !is Undefined


### PR DESCRIPTION
## Summary
Six small docstring/comment fixes:
- `Pos.LineColPos`: *columnn* → *column*
- `nodes.kt` `isDefined`: *Returnes true* → *Returns true*
- `ConfigSource.fromResourcesOrFiles` (×2): *fileystem* → *filesystem*
- `DecoderContext.usedPaths` comment: *overrided* → *overridden*
- `DecoderContext.used()`: *Makes a node as marshalled* → *Marks a node as marshalled* (the previous wording was nonsense — the function records that a node has been used, it doesn't manufacture one)
- `Cascader.cascade` docstring: *preccence* → *precedence*

No behaviour change.

## Test plan
- [x] Compile-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)