### PR TITLE
SecretFilesPreprocessor: surface missing-file as a clean ConfigFailure

### DIFF
--- a/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/preprocessor/SecretFilesPreprocessor.kt
+++ b/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/preprocessor/SecretFilesPreprocessor.kt
@@ -2,12 +2,15 @@
 
 package com.sksamuel.hoplite.preprocessor
 
+import com.sksamuel.hoplite.ConfigFailure
 import com.sksamuel.hoplite.ConfigResult
 import com.sksamuel.hoplite.DecoderContext
 import com.sksamuel.hoplite.Node
 import com.sksamuel.hoplite.PrimitiveNode
 import com.sksamuel.hoplite.StringNode
+import com.sksamuel.hoplite.fp.invalid
 import com.sksamuel.hoplite.fp.valid
+import java.nio.file.NoSuchFileException
 import java.nio.file.Path
 import kotlin.io.path.readText
 
@@ -28,11 +31,21 @@ class SecretFilesPreprocessor(private val basePath: Path) : TraversingPrimitiveP
 
   override fun handle(node: PrimitiveNode, context: DecoderContext): ConfigResult<Node> = when (node) {
     is StringNode -> {
-      val replaced = regex.replace(node.value) { match ->
-        val key = match.groupValues[1]
-        basePath.resolve(key).readText().trimEnd('\r', '\n')
+      // Surface a missing secret file as a clean ConfigFailure rather than letting
+      // NoSuchFileException (or any other I/O failure) escape from the preprocessor and
+      // crash the loader with a stack trace. The user typo'd or forgot to mount the secret
+      // — they should see "secret 'x' not found at <path>" in the failure report.
+      try {
+        val replaced = regex.replace(node.value) { match ->
+          val key = match.groupValues[1]
+          basePath.resolve(key).readText().trimEnd('\r', '\n')
+        }
+        if (replaced == node.value) node.valid() else node.copy(value = replaced).valid()
+      } catch (e: NoSuchFileException) {
+        ConfigFailure.PreprocessorWarning("Secret file '${e.file}' not found").invalid()
+      } catch (e: Exception) {
+        ConfigFailure.PreprocessorFailure("Failed reading secret file from $basePath", e).invalid()
       }
-      if (replaced == node.value) node.valid() else node.copy(value = replaced).valid()
     }
     else -> node.valid()
   }

--- a/hoplite-core/src/test/kotlin/com/sksamuel/hoplite/preprocessor/SecretFilesPreprocessorTest.kt
+++ b/hoplite-core/src/test/kotlin/com/sksamuel/hoplite/preprocessor/SecretFilesPreprocessorTest.kt
@@ -106,6 +106,26 @@ class SecretFilesPreprocessorTest : FunSpec({
     config shouldBe Config(url = "jdbc://alice@db.internal/db")
   }
 
+  test("returns a clean ConfigFailure when the referenced secret file is missing") {
+    val secrets = tempdir() // empty directory — no secret files written
+
+    data class Config(val apiKey: String)
+
+    val ex = io.kotest.assertions.throwables.shouldThrow<com.sksamuel.hoplite.ConfigException> {
+      ConfigLoaderBuilder.default()
+        .addPreprocessor(SecretFilesPreprocessor(secrets.toPath()))
+        .addPropertySource(PropertySource.string("apiKey=\${secret:apiKey}", "props"))
+        .build()
+        .loadConfigOrThrow<Config>()
+    }
+    // Before the fix: an uncaught NoSuchFileException made it out as a generic stack trace.
+    // After the fix: a clean preprocessor warning identifying the missing file.
+    val msg = ex.message.orEmpty()
+    assert("Secret file" in msg && "not found" in msg) {
+      "Expected 'Secret file ... not found' in error, was: $msg"
+    }
+  }
+
   test("accepts a string base path via the convenience constructor") {
     val secrets = tempdir().apply { writeSecret("apiKey", "abc-123") }
 


### PR DESCRIPTION
## Summary
A typo'd or unmounted secret file caused `regex.replace`'s lambda to call `Path.readText()`, which throws `NoSuchFileException`. The exception propagated straight out of the preprocessor and crashed the loader with a generic stack trace pointing at hoplite internals — instead of the much more useful *"secret 'X' not found at /path"* the user actually needed.

Wrap the `regex.replace` block in a `try/catch` and turn the IO failure into a `ConfigFailure.PreprocessorWarning` naming the missing file (or `PreprocessorFailure` for any other IO error).

Also closes a small gap in #547 — the merged version had inherited the original lack of error handling.

## Tests
A regression test in `SecretFilesPreprocessorTest` (`returns a clean ConfigFailure when the referenced secret file is missing`) exercises the missing-file case. Verified it fails against the un-patched preprocessor.

## Test plan
- [x] `./gradlew :hoplite-core:test --tests SecretFilesPreprocessorTest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)