### PR TITLE
docs: fix JsonPropertySource example referencing the wrong class

### DIFF
--- a/hoplite-json/src/main/kotlin/com/sksamuel/hoplite/json/JsonPropertySource.kt
+++ b/hoplite-json/src/main/kotlin/com/sksamuel/hoplite/json/JsonPropertySource.kt
@@ -14,7 +14,7 @@ private val counter = AtomicInteger(0)
  *
  * For example:
  *
- *   JsonParser(
+ *   JsonPropertySource(
  *      """ {
  *        "a": [
  *          {


### PR DESCRIPTION
## Summary
The `JsonPropertySource` KDoc showed `JsonParser(""" ... """)` as the example, but `JsonParser` only has a `JsonFactory` (or no-arg) constructor — copying the example verbatim would not compile. Should be `JsonPropertySource(...)`, the class being documented.

## Test plan
- [x] No code changes — KDoc only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)