### PR TITLE
YamlParser: resolve aliases to anchored sequences

### DIFF
--- a/hoplite-yaml/src/main/kotlin/com/sksamuel/hoplite/yaml/YamlParser.kt
+++ b/hoplite-yaml/src/main/kotlin/com/sksamuel/hoplite/yaml/YamlParser.kt
@@ -171,7 +171,8 @@ object SequenceProduction {
     require(
       stream.current().`is`(Event.ID.SequenceStart)
     ) { "Expected sequence start at ${stream.current().startMark}" }
-    val mark = stream.current().startMark
+    val seqEvent = stream.current() as SequenceStartEvent
+    val mark = seqEvent.startMark
     val list = mutableListOf<Node>()
     var index = 0
     var tempAnchors: Map<String, Node> = anchors
@@ -182,7 +183,15 @@ object SequenceProduction {
       tempAnchors = returnedAnchors
     }
     require(stream.current().`is`(Event.ID.SequenceEnd)) { "Expected sequence end at ${stream.current().startMark}" }
-    return Pair(ArrayNode(list.toList(), mark.toPos(source), path), tempAnchors)
+    val node = ArrayNode(list.toList(), mark.toPos(source), path)
+    // Register the sequence's own anchor (if any) so a later alias can resolve it,
+    // mirroring how MapProduction and the scalar branch handle anchors. Without this,
+    // an anchored sequence (`&a [ ... ]`) referenced by `*a` failed with "Could not find alias".
+    tempAnchors = when (val anchor = seqEvent.anchor) {
+      null -> tempAnchors
+      else -> tempAnchors + Pair(anchor, node)
+    }
+    return Pair(node, tempAnchors)
   }
 }
 

--- a/hoplite-yaml/src/test/kotlin/com/sksamuel/hoplite/yaml/AnchorAliasTest.kt
+++ b/hoplite-yaml/src/test/kotlin/com/sksamuel/hoplite/yaml/AnchorAliasTest.kt
@@ -1,6 +1,7 @@
 package com.sksamuel.hoplite.yaml
 
 import com.sksamuel.hoplite.ConfigLoader
+import com.sksamuel.hoplite.PropertySource
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 
@@ -21,6 +22,24 @@ class AnchorAliasTest : FunSpec() {
         Hand("The Bastard Sword of Eowyn", 30),
         Hand("The Bastard Sword of Eowyn", 30)
       )
+    }
+
+    test("should support anchors and aliases on sequences") {
+      data class Test(val defaults: List<String>, val other: List<String>)
+
+      val yaml = """
+        defaults: &d
+          - a
+          - b
+        other: *d
+      """.trimIndent()
+
+      val config = ConfigLoader.builder()
+        .addPropertySource(PropertySource.string(yaml, "yml"))
+        .build()
+        .loadConfigOrThrow<Test>()
+
+      config shouldBe Test(listOf("a", "b"), listOf("a", "b"))
     }
   }
 }


### PR DESCRIPTION
## Problem

YAML anchors (`&name`) on **sequences** are silently dropped, so any alias (`*name`) referencing an anchored sequence fails to resolve:

```yaml
defaults: &d
  - a
  - b
other: *d
```

Loading this throws `Could not find alias d`. Anchored **scalars** and **maps** work fine — only sequences are affected.

## Cause

`SequenceProduction` builds the `ArrayNode` but never registers the sequence's own anchor in the `anchors` map. Compare with `MapProduction`, which captures `mapEvent.anchor`, and the scalar branch in `TokenProduction`, which captures `event.anchor`. `SequenceStartEvent` carries `getAnchor()` exactly like `MappingStartEvent`, but it was never read.

## Fix

Capture the `SequenceStartEvent` and register the resulting `ArrayNode` under its anchor before returning, mirroring the existing map/scalar handling.

## Test

Added a case to `AnchorAliasTest` exercising an anchored sequence referenced via an alias. It fails on `master` (`Could not find alias d`) and passes with this change. Full `hoplite-yaml` suite is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)