### PR TITLE
CommandLinePropertySource: don't crash when delimiter is a substring of the prefix

### DIFF
--- a/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/sources/CommandLinePropertySource.kt
+++ b/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/sources/CommandLinePropertySource.kt
@@ -23,7 +23,11 @@ class CommandLinePropertySource(
 
   override fun node(context: PropertySourceContext): ConfigResult<Node> {
     val values = arguments.asSequence().filter {
-      it.startsWith(prefix) && it.contains(delimiter)
+      // The delimiter must appear in the key portion (after the prefix is stripped), not just
+      // anywhere in the raw argument. Checking the raw argument means an arg whose only delimiter
+      // is inside the prefix (e.g. prefix "--", delimiter "-", arg "--verbose") passes the filter
+      // but then splits into a single element, and the value lookup at index 1 throws.
+      it.startsWith(prefix) && it.removePrefix(prefix).contains(delimiter)
     }.map {
       it.removePrefix(prefix).split(delimiter, limit = 2)
     }.groupingBy {

--- a/hoplite-core/src/test/kotlin/com/sksamuel/hoplite/sources/CommandLinePropertySourceTest.kt
+++ b/hoplite-core/src/test/kotlin/com/sksamuel/hoplite/sources/CommandLinePropertySourceTest.kt
@@ -1,0 +1,38 @@
+package com.sksamuel.hoplite.sources
+
+import com.sksamuel.hoplite.ConfigLoader
+import com.sksamuel.hoplite.addCommandLineSource
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+class CommandLinePropertySourceTest : FunSpec() {
+  init {
+
+    test("should parse prefixed key=value arguments") {
+      data class Config(val foo: String, val bar: String)
+
+      val config = ConfigLoader.builder()
+        .addCommandLineSource(arrayOf("--foo=hello", "--bar=world", "ignored=nope"))
+        .build()
+        .loadConfigOrThrow<Config>()
+
+      config shouldBe Config("hello", "world")
+    }
+
+    // When the delimiter is a substring of the prefix (e.g. prefix "--", delimiter "-"),
+    // a flag-style argument with no delimiter in its key portion (e.g. "--verbose") used to
+    // crash with IndexOutOfBoundsException: the "contains(delimiter)" guard was applied to the
+    // raw argument (which contains the delimiter inside the prefix) rather than to the
+    // post-prefix key, so the split produced no value and element[1] was accessed.
+    test("should skip prefixed arguments with no delimiter in the key portion") {
+      data class Config(val foo: String)
+
+      val config = ConfigLoader.builder()
+        .addCommandLineSource(arrayOf("--verbose", "--foo-bar"), prefix = "--", delimiter = "-")
+        .build()
+        .loadConfigOrThrow<Config>()
+
+      config shouldBe Config("bar")
+    }
+  }
+}


### PR DESCRIPTION
## Problem

`CommandLinePropertySource` crashes the entire config load with `IndexOutOfBoundsException: Index: 1, Size: 1` for a flag-style argument when the delimiter happens to be a substring of the prefix.

Example — prefix `--`, delimiter `-`, args `["--verbose", "--foo-bar"]`:

```
java.lang.IndexOutOfBoundsException: Index: 1, Size: 1
```

`--verbose` has no delimiter in its **key** (`verbose`), so it should simply be ignored.

## Cause

```kotlin
arguments.asSequence().filter {
  it.startsWith(prefix) && it.contains(delimiter)   // checks the RAW argument
}.map {
  it.removePrefix(prefix).split(delimiter, limit = 2) // but splits the post-prefix key
}
```

The filter's `contains(delimiter)` is applied to the raw argument, while the split happens on `removePrefix(prefix)`. When the delimiter occurs only inside the prefix (e.g. the `-` inside `--`), the filter passes but the split yields a single element, and the later `element[1]` value lookup throws.

## Fix

Apply the delimiter check to the post-prefix key:

```kotlin
it.startsWith(prefix) && it.removePrefix(prefix).contains(delimiter)
```

This is behaviour-preserving whenever the delimiter is not a substring of the prefix (the default `--` / `=` case), and skips delimiter-less flags otherwise instead of crashing.

## Test

Added `CommandLinePropertySourceTest` with the reproducing case (fails on `master` with the IOOBE above, passes here) plus a basic `key=value` parse case to guard the happy path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)