### PR TITLE
HashObfuscator: emit the documented number of hash characters

### DIFF
--- a/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/secrets/Obfuscator.kt
+++ b/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/secrets/Obfuscator.kt
@@ -50,10 +50,13 @@ class HashObfuscator(private val hashCharsToShow: Int = 8) : Obfuscator {
       is StringNode -> {
         if (isNumericOrBoolean(node.value)) return node.value
         val digest = MessageDigest.getInstance("SHA-256")
-        return digest
+        // `take(hashCharsToShow)` must be applied to the hex string, not the raw bytes:
+        // each byte renders as two hex chars, so taking n bytes first yielded 2n characters
+        // instead of the n promised by the docstring and the `hashCharsToShow` parameter name.
+        val hex = digest
           .digest(node.value.encodeToByteArray())
-          .take(hashCharsToShow)
-          .joinToString("", "hash(", "...)") { "%02x".format(it) }
+          .joinToString("") { "%02x".format(it) }
+        return "hash(${hex.take(hashCharsToShow)}...)"
       }
     }
   }

--- a/hoplite-core/src/test/kotlin/com/sksamuel/hoplite/report/HashObfuscatorTest.kt
+++ b/hoplite-core/src/test/kotlin/com/sksamuel/hoplite/report/HashObfuscatorTest.kt
@@ -1,0 +1,38 @@
+package com.sksamuel.hoplite.report
+
+import com.sksamuel.hoplite.BooleanNode
+import com.sksamuel.hoplite.DoubleNode
+import com.sksamuel.hoplite.LongNode
+import com.sksamuel.hoplite.Pos
+import com.sksamuel.hoplite.StringNode
+import com.sksamuel.hoplite.decoder.DotPath
+import com.sksamuel.hoplite.secrets.HashObfuscator
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import java.security.MessageDigest
+
+class HashObfuscatorTest : FunSpec({
+
+  fun sha256Hex(value: String): String =
+    MessageDigest.getInstance("SHA-256")
+      .digest(value.encodeToByteArray())
+      .joinToString("") { "%02x".format(it) }
+
+  test("should show exactly hashCharsToShow characters of the hex hash") {
+    val value = "super-secret-password"
+    val expected = sha256Hex(value)
+
+    HashObfuscator(8).obfuscate(StringNode(value, Pos.NoPos, DotPath.root))
+      .shouldBe("hash(${expected.take(8)}...)")
+
+    HashObfuscator(12).obfuscate(StringNode(value, Pos.NoPos, DotPath.root))
+      .shouldBe("hash(${expected.take(12)}...)")
+  }
+
+  test("non-strings and numeric strings should not be obfuscated") {
+    HashObfuscator(8).obfuscate(BooleanNode(true, Pos.NoPos, DotPath.root)).shouldBe("true")
+    HashObfuscator(8).obfuscate(LongNode(324, Pos.NoPos, DotPath.root)).shouldBe("324")
+    HashObfuscator(8).obfuscate(DoubleNode(1.23, Pos.NoPos, DotPath.root)).shouldBe("1.23")
+    HashObfuscator(8).obfuscate(StringNode("42", Pos.NoPos, DotPath.root)).shouldBe("42")
+  }
+})


### PR DESCRIPTION
## Problem

`HashObfuscator` shows **twice** the number of hash characters its contract promises. Both the docstring and the parameter name specify *characters*:

- Docstring: "takes the **first n characters of the SHA-256 hash**"
- Parameter: `hashCharsToShow` (default `8`)

But with the default it renders **16** hex characters, e.g. `hash(f52fbd32b2b3b86f...)` instead of `hash(f52fbd32...)`.

## Cause

```kotlin
digest.digest(node.value.encodeToByteArray())
  .take(hashCharsToShow)                              // takes n BYTES
  .joinToString("", "hash(", "...)") { "%02x".format(it) }  // each byte -> 2 hex chars
```

`take(hashCharsToShow)` is applied to the raw `ByteArray`. Each retained byte is then formatted as two hex characters, so the output length is `2 * hashCharsToShow`.

## Fix

Hex-encode the full digest first, then take `hashCharsToShow` characters:

```kotlin
val hex = digest.digest(node.value.encodeToByteArray())
  .joinToString("") { "%02x".format(it) }
return "hash(${hex.take(hashCharsToShow)}...)"
```

## Test

Added `HashObfuscatorTest` asserting the emitted hash equals the first `hashCharsToShow` characters of the full hex digest (for two values of the parameter), plus coverage of the numeric/boolean pass-through paths. The char-count assertion fails on `master` (16 chars) and passes here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)