### PR TITLE
Cascader: don't drop overrides on a map node's own value

### DIFF
--- a/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/internal/cascade.kt
+++ b/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/internal/cascade.kt
@@ -68,10 +68,14 @@ class Cascader(
               val keys = a.map.keys + b.map.keys
               val merges: Map<String, CascadeResult> =
                 keys.associateWith { cascade(a.atKey(it), b.atKey(it)) }
-              val overrides = merges.values.toList().flatMap { it.overrides }
+              // Also merge the maps' own scalar `value` (the "dual" leaf+map case) and fold in any
+              // overrides it produces — otherwise a conflict on the value itself is silently dropped
+              // and CascadeMode.Error would not flag it.
+              val valueResult = cascade(a.value, b.value)
+              val overrides = merges.values.toList().flatMap { it.overrides } + valueResult.overrides
               val elements = merges.mapValues { it.value.node }
               CascadeResult(
-                MapNode(elements, a.pos, a.path, cascade(a.value, b.value).node, a.meta, a.delimiter, a.sourceKey),
+                MapNode(elements, a.pos, a.path, valueResult.node, a.meta, a.delimiter, a.sourceKey),
                 overrides
               )
             }

--- a/hoplite-core/src/test/kotlin/com/sksamuel/hoplite/CascadeTest.kt
+++ b/hoplite-core/src/test/kotlin/com/sksamuel/hoplite/CascadeTest.kt
@@ -177,6 +177,30 @@ class CascadeTest : FunSpec({
     )
   }
 
+  test("cascade function should report an override on a map node's own value") {
+    // A "dual" node is both a leaf value and a map (e.g. props `db = primary` plus `db.host = ...`),
+    // represented as a MapNode with a non-Undefined `value`. When two sources both define such a
+    // value, the conflict on the value itself must be reported as an override.
+    val node1 = MapNode(
+      map = mapOf("host" to StringNode("localhost", Pos.NoPos, DotPath("db", "host"))),
+      pos = Pos.NoPos,
+      path = DotPath("db"),
+      value = StringNode("primary", Pos.SourcePos("y"), DotPath("db"))
+    )
+
+    val node2 = MapNode(
+      map = emptyMap(),
+      pos = Pos.NoPos,
+      path = DotPath("db"),
+      value = StringNode("secondary", Pos.SourcePos("x"), DotPath("db"))
+    )
+
+    val cascader = Cascader(CascadeMode.Merge, false)
+    cascader.cascade(node1, node2).overrides shouldBe listOf(
+      OverridePath(DotPath("db"), Pos.SourcePos("y"), Pos.SourcePos("x"))
+    )
+  }
+
   test("CascadeMode.error should error if overrides present") {
     shouldThrowAny {
       ConfigLoaderBuilder.default()


### PR DESCRIPTION
## Problem

When two config sources both define a key that is **simultaneously a leaf value and a map** (a "dual" node — e.g. `db = primary` together with `db.host = localhost`), a conflict on the *value* part is silently swallowed. Under `CascadeMode.Error` the load succeeds even though there is a genuine override.

## Cause

In the `MapNode` + `MapNode` merge branch of `cascade`:

```kotlin
val overrides = merges.values.toList().flatMap { it.overrides }   // only per-key overrides
...
MapNode(elements, a.pos, a.path, cascade(a.value, b.value).node, ...)  // .node kept, .overrides DROPPED
```

The per-key merges contribute their overrides, but the merge of the maps' own `value` field takes only `.node` and discards the `CascadeResult.overrides`. When both maps have a defined `value`, that cascade produces an `OverridePath` which is then thrown away.

## Fix

Capture the value-cascade result and fold its overrides into the merged node's override list:

```kotlin
val valueResult = cascade(a.value, b.value)
val overrides = merges.values.toList().flatMap { it.overrides } + valueResult.overrides
...
MapNode(elements, a.pos, a.path, valueResult.node, ...)
```

## Test

Added a `CascadeTest` case (modeled on the existing "should return all overrides" test) merging two `MapNode`s that each carry a `value`. It asserts the resulting `OverridePath` is reported. Fails on `master` (`overrides` is empty), passes here. Full `hoplite-core` suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)