### PR TITLE
ContextResolver: split key/default on the first ':-' so defaults can contain ':-'

### DIFF
--- a/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/resolver/context/ContextResolver.kt
+++ b/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/resolver/context/ContextResolver.kt
@@ -40,7 +40,11 @@ abstract class ContextResolver : Resolver {
   // redundant escaping required for Android support
   private fun prefixRegex() = "$contextKey://(.*)".toRegex()
 
-  private val valueWithDefaultRegex = "(.+):-(.+)".toRegex()
+  // The first group is lazy so the split happens on the FIRST ":-": lookup keys (env var /
+  // sysprop / ref names) cannot contain ":-", but default values can, so the default must keep
+  // any ":-" it contains. A greedy first group split on the last ":-" instead. This matches the
+  // lazy form already used by EnvOrSystemPropertyPreprocessor and LookupPreprocessor.
+  private val valueWithDefaultRegex = "(.+?):-(.+)".toRegex()
 
   /**
    * Return the replacement value, or null if no replacement should take place.

--- a/hoplite-core/src/test/kotlin/com/sksamuel/hoplite/resolver/context/SystemPropertyContextResolverEmptyKeyTest.kt
+++ b/hoplite-core/src/test/kotlin/com/sksamuel/hoplite/resolver/context/SystemPropertyContextResolverEmptyKeyTest.kt
@@ -33,4 +33,17 @@ class SystemPropertyContextResolverEmptyKeyTest : FunSpec({
       .loadConfigOrThrow<Cfg>()
     cfg.a shouldBe "fallback"
   }
+
+  // A default value may itself contain ":-". The key/default split must happen on the FIRST ":-"
+  // (lookup keys are property/env names and cannot contain ":-"), not the last. A greedy first
+  // group split on the last ":-", so the fallback below resolved to "b" instead of "a:-b".
+  test("\${{ sysprop:somekey :- default }} keeps a ':-' that appears in the default value") {
+    System.clearProperty("hoplite.unset.test.key")
+    data class Cfg(val a: String)
+    val cfg = ConfigLoaderBuilder.newBuilderWithoutPropertySources()
+      .addMapSource(mapOf("a" to "\${{ sysprop:hoplite.unset.test.key :- a:-b }}"))
+      .build()
+      .loadConfigOrThrow<Cfg>()
+    cfg.a shouldBe "a:-b"
+  }
 })


### PR DESCRIPTION
## Problem

Context substitutions support a default via `:-`, e.g. `${{ env:NAME :- fallback }}`. But when the **default value itself contains `:-`**, the wrong split is taken:

```
${{ sysprop:hoplite.unset.key :- a:-b }}   ->  "b"   (should be "a:-b")
```

## Cause

```kotlin
private val valueWithDefaultRegex = "(.+):-(.+)".toRegex()
```

The first group `(.+)` is **greedy**, so `matchEntire` splits on the **last** `:-` in the path. The lookup key wrongly absorbs the leading part of the default (`hoplite.unset.key :- a`), and the default collapses to just `b`.

Lookup keys are env-var / sysprop / `ref` names and can never legitimately contain `:-`, so the split must always be on the **first** `:-`. The two sibling preprocessors already use the lazy/first-split form (`EnvOrSystemPropertyPreprocessor`, `LookupPreprocessor`), confirming the greedy form here is an oversight.

## Fix

```kotlin
private val valueWithDefaultRegex = "(.+?):-(.+)".toRegex()
```

Lazy first group → split on the first `:-`, so the default keeps any `:-` it contains.

## Test

Added a case to `SystemPropertyContextResolverEmptyKeyTest` with a default containing `:-`. Fails on `master` (`expected:<a:-b> but was:<b>`), passes here. Full `hoplite-core` suite green; the existing `:- fallback` test still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)