### PR TITLE
ReloadableConfig: publish errorHandler safely to the watcher thread (@Volatile)

### DIFF
--- a/hoplite-watch/src/main/kotlin/com/sksamuel/hoplite/watch/ReloadableConfig.kt
+++ b/hoplite-watch/src/main/kotlin/com/sksamuel/hoplite/watch/ReloadableConfig.kt
@@ -24,6 +24,11 @@ class ReloadableConfig<A : Any>(
 ) {
 
   private val config = AtomicReference(configLoader.loadConfigOrThrow(clazz, emptyList()))
+
+  // Written on the caller thread via withErrorHandler, read on the watcher thread (reloadConfig and
+  // the watch error callback). Volatile establishes the happens-before edge so the watcher thread is
+  // guaranteed to see the handler once set; config and subscribers are already thread-safe.
+  @Volatile
   private var errorHandler: ((Throwable) -> Unit)? = null
   private val subscribers = ConcurrentHashMap.newKeySet<(A) -> Unit>()
 


### PR DESCRIPTION
## Problem

`ReloadableConfig.errorHandler` is a plain `var`:

```kotlin
private var errorHandler: ((Throwable) -> Unit)? = null
```

It is **written on the caller thread** (`withErrorHandler`) but **read on the watcher thread** — both in `reloadConfig()` (`errorHandler?.invoke(it)`) and in the watch error callback passed to `addWatcher`. There is no happens-before edge between the write and the read, so under the Java Memory Model the watcher thread is not guaranteed to observe the handler once it is set, and a reload error can be silently dropped.

The other shared fields are already memory-safe (`config` is an `AtomicReference`, `subscribers` is a `ConcurrentHashMap` key set) — `errorHandler` is the lone unguarded field.

## Fix

```kotlin
@Volatile
private var errorHandler: ((Throwable) -> Unit)? = null
```

`@Volatile` establishes the happens-before edge so the handler, once set, is reliably visible to the watcher thread.

## Scope / honesty note

This fixes **visibility** only. It does **not** address a separate *ordering* concern: the fluent API allows `withErrorHandler { }` to be called *after* `addWatcher(...)` has already started the watcher (this is the documented usage), so an error fired in that brief startup window still finds no handler set. That ordering race is an API-design question and is intentionally left out of scope.

Because this is a memory-visibility issue, there is no deterministic unit test that fails on `master` and passes here (the race won't reliably manifest on strongly-ordered hardware), so no test is added — the existing single-threaded `"will call the provided error handler…"` test already covers the functional contract. The full `:hoplite-watch:test` suite passes with the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)