### PR TITLE
loadProps: preserve null elements in list values instead of dropping them

### DIFF
--- a/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/parsers/loadProps.kt
+++ b/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/parsers/loadProps.kt
@@ -3,6 +3,7 @@ package com.sksamuel.hoplite.parsers
 import com.sksamuel.hoplite.ArrayNode
 import com.sksamuel.hoplite.MapNode
 import com.sksamuel.hoplite.Node
+import com.sksamuel.hoplite.NullNode
 import com.sksamuel.hoplite.Pos
 import com.sksamuel.hoplite.StringNode
 import com.sksamuel.hoplite.Undefined
@@ -79,15 +80,17 @@ private fun <T, K> Iterable<T>.toNode(
         delimiter = delimiter,
       )
     }
+    // Map null elements to NullNode rather than dropping them — mapNotNull would silently shift
+    // every later element's index left by one, corrupting positional decoding of e.g. List<String?>.
     is Array<*> -> ArrayNode(
-      elements = mapNotNull { it?.transform(path, parentSourceKey) },
+      elements = map { it?.transform(path, parentSourceKey) ?: NullNode(pos, path, emptyMap(), delimiter, parentSourceKey) },
       pos = pos,
       path = path,
       sourceKey = parentSourceKey,
       delimiter = delimiter,
     )
     is Collection<*> -> ArrayNode(
-      elements = mapNotNull { it?.transform(path, parentSourceKey) },
+      elements = map { it?.transform(path, parentSourceKey) ?: NullNode(pos, path, emptyMap(), delimiter, parentSourceKey) },
       pos = pos,
       path = path,
       sourceKey = parentSourceKey,

--- a/hoplite-core/src/test/kotlin/com/sksamuel/hoplite/parsers/LoadPropsArrayNullTest.kt
+++ b/hoplite-core/src/test/kotlin/com/sksamuel/hoplite/parsers/LoadPropsArrayNullTest.kt
@@ -1,0 +1,25 @@
+package com.sksamuel.hoplite.parsers
+
+import com.sksamuel.hoplite.ConfigLoaderBuilder
+import com.sksamuel.hoplite.ExperimentalHoplite
+import com.sksamuel.hoplite.sources.MapPropertySource
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+@OptIn(ExperimentalHoplite::class)
+class LoadPropsArrayNullTest : FunSpec({
+
+  // A null element in a list value must be preserved at its position. Previously the transform
+  // used mapNotNull, which dropped nulls and shifted every later element left by one — so
+  // ["x", null, "y"] decoded to index 1 = "y" instead of null.
+  test("a null element in a list value is preserved at its index") {
+    data class Cfg(val a: List<String?>)
+
+    val cfg = ConfigLoaderBuilder.newBuilderWithoutPropertySources()
+      .addPropertySource(MapPropertySource(mapOf("a" to listOf("x", null, "y"))))
+      .build()
+      .loadConfigOrThrow<Cfg>()
+
+    cfg.a shouldBe listOf("x", null, "y")
+  }
+})


### PR DESCRIPTION
## Problem

A `null` element inside a list value is silently dropped, and every element after it shifts one position to the left:

```kotlin
MapPropertySource(mapOf("a" to listOf("x", null, "y")))
// decoding `a: List<String?>` yields ["x", "y"] — index 1 is "y", not null
```

The null at index 1 is lost and `"y"` ends up at the wrong index — positional data corruption.

## Cause

In `loadProps.kt`, the `Array<*>` and `Collection<*>` branches build the `ArrayNode` with:

```kotlin
elements = mapNotNull { it?.transform(path, parentSourceKey) }
```

`mapNotNull` drops the result for any `null` element, collapsing the list and shifting indices.

## Fix

Map a `null` element to a `NullNode` so its position is preserved:

```kotlin
elements = map { it?.transform(path, parentSourceKey)
                 ?: NullNode(pos, path, emptyMap(), delimiter, parentSourceKey) }
```

Scoped to the array/collection branches. The `Map<*,*>` branch (where a null value drops the key) is intentionally left unchanged — "null value means absent key" is a defensible map semantics, unlike the positional corruption in lists.

## Test

Added `LoadPropsArrayNullTest`: a list `["x", null, "y"]` via `MapPropertySource`, decoded to `List<String?>`. Fails on `master` (`expected:<["x", null, "y"]> but was:<["x", "y"]>`), passes here. Full multi-module test suite is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)