### PR TITLE
Random resolver/preprocessor: never return a negative int/long

### DIFF
--- a/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/preprocessor/RandomPreprocessor.kt
+++ b/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/preprocessor/RandomPreprocessor.kt
@@ -10,7 +10,6 @@ import com.sksamuel.hoplite.StringNode
 import com.sksamuel.hoplite.fp.valid
 import com.sksamuel.hoplite.DecoderContext
 import java.util.UUID
-import kotlin.math.abs
 import kotlin.random.Random
 
 private typealias Rule = (String) -> String
@@ -22,7 +21,8 @@ object RandomPreprocessor : TraversingPrimitivePreprocessor() {
 
   private val intRule: Rule = {
     val regex = "\\$\\{random.int\\}".toRegex()
-    regex.replace(it) { abs(Random.nextInt()).toString() }
+    // Mask off the sign bit rather than abs(): abs(Int.MIN_VALUE) == Int.MIN_VALUE (overflow).
+    regex.replace(it) { (Random.nextInt() and Int.MAX_VALUE).toString() }
   }
 
   private val booleanRule: Rule = {
@@ -55,7 +55,8 @@ object RandomPreprocessor : TraversingPrimitivePreprocessor() {
 
   private val longRule: Rule = {
     val regex = "\\$\\{random.long\\}".toRegex()
-    regex.replace(it) { abs(Random.nextLong()).toString() }
+    // Mask off the sign bit rather than abs(): abs(Long.MIN_VALUE) == Long.MIN_VALUE (overflow).
+    regex.replace(it) { (Random.nextLong() and Long.MAX_VALUE).toString() }
   }
 
   private val doubleRule: Rule = {

--- a/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/resolver/context/RandomContextResolver.kt
+++ b/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/resolver/context/RandomContextResolver.kt
@@ -8,7 +8,6 @@ import com.sksamuel.hoplite.StringNode
 import com.sksamuel.hoplite.fp.invalid
 import com.sksamuel.hoplite.fp.valid
 import java.util.UUID
-import kotlin.math.abs
 import kotlin.random.Random
 
 object RandomContextResolver : ContextResolver() {
@@ -29,10 +28,14 @@ object RandomContextResolver : ContextResolver() {
 
   override fun lookup(path: String, node: StringNode, root: Node, context: DecoderContext): ConfigResult<String?> {
     return when (path) {
-      "int" -> abs(Random.nextInt()).toString().valid()
+      // Mask off the sign bit rather than abs(): abs(Int.MIN_VALUE) == Int.MIN_VALUE (overflow),
+      // so abs(Random.nextInt()) can still return a negative number. `and Int.MAX_VALUE` is always
+      // non-negative and stays uniform over [0, Int.MAX_VALUE].
+      "int" -> (Random.nextInt() and Int.MAX_VALUE).toString().valid()
       "boolean" -> Random.nextBoolean().toString().valid()
-      "long" -> abs(Random.nextLong()).toString().valid()
-      "double" -> abs(Random.nextDouble()).toString().valid()
+      "long" -> (Random.nextLong() and Long.MAX_VALUE).toString().valid()
+      // nextDouble() is already in [0.0, 1.0), so it is always non-negative; no abs needed.
+      "double" -> Random.nextDouble().toString().valid()
       "uuid" -> UUID.randomUUID().toString().valid()
       else -> {
         val intWithMaxMatch = intWithMaxRule.matchEntire(path)


### PR DESCRIPTION
## Problem

`random:int` / `${random.int}` and `random:long` / `${random.long}` use `abs()` to make the value non-negative:

```kotlin
"int"  -> abs(Random.nextInt()).toString().valid()
"long" -> abs(Random.nextLong()).toString().valid()
```

But `abs(Int.MIN_VALUE) == Int.MIN_VALUE` and `abs(Long.MIN_VALUE) == Long.MIN_VALUE` — two's-complement has no positive counterpart for the minimum value, so `abs()` overflows and returns the same negative number. When `Random.nextInt()` happens to produce `Int.MIN_VALUE` (likewise for long), the result is **negative**, contrary to the evident intent of the `abs()` call.

## Fix

Mask off the sign bit instead, which is always non-negative and remains uniform over `[0, MAX_VALUE]`:

```kotlin
"int"  -> (Random.nextInt() and Int.MAX_VALUE).toString().valid()
"long" -> (Random.nextLong() and Long.MAX_VALUE).toString().valid()
```

(`and MAX_VALUE` is preferred over `nextInt(0, MAX_VALUE)`, which would exclude `MAX_VALUE` and be slightly non-uniform.)

Also dropped the redundant `abs()` on `random:double` in `RandomContextResolver` — `Random.nextDouble()` is already in `[0.0, 1.0)`.

## Note on testing

This is a `1/2³²` (resp. `1/2⁶⁴`) overflow edge that uses the global `Random`, so there is no deterministic unit test that reliably reproduces it (the bad value can't be forced through the public API). The fix is provable by construction — `x and Int.MAX_VALUE >= 0` for all `x`, including `Int.MIN_VALUE`. The existing random resolver/preprocessor tests and the full `hoplite-core` suite stay green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)