### PR TITLE
LookupPreprocessor: resolve cased/dashed paths when PathNormalizer is active (#503)

### DIFF
--- a/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/preprocessor/LookupPreprocessor.kt
+++ b/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/preprocessor/LookupPreprocessor.kt
@@ -10,6 +10,7 @@ import com.sksamuel.hoplite.Node
 import com.sksamuel.hoplite.StringNode
 import com.sksamuel.hoplite.fp.valid
 import com.sksamuel.hoplite.DecoderContext
+import com.sksamuel.hoplite.transformer.PathNormalizer
 import com.sksamuel.hoplite.withMeta
 
 /**
@@ -27,9 +28,17 @@ object LookupPreprocessor : Preprocessor {
 
   override fun process(node: Node, context: DecoderContext): ConfigResult<Node> {
 
-    fun lookup(key: String): String? = when (val n = node.atPath(key)) {
-      is StringNode -> n.value
-      else -> null
+    // When PathNormalizer is active it has lowercased and stripped -/_ from every tree key, so the
+    // lookup key must be normalized the same way or a cased/dashed path would no longer match (#503).
+    // transformPathElement leaves '.' untouched, so it can be applied to the whole dotted path —
+    // this mirrors how ConfigParser.prefixedNode normalizes a prefix before atPath.
+    fun lookup(key: String): String? {
+      val normalizedKey =
+        if (context.nodeTransformers.contains(PathNormalizer)) PathNormalizer.transformPathElement(key) else key
+      return when (val n = node.atPath(normalizedKey)) {
+        is StringNode -> n.value
+        else -> null
+      }
     }
 
     fun replace(node: StringNode, regex: Regex): StringNode {

--- a/hoplite-core/src/test/kotlin/com/sksamuel/hoplite/preprocessor/LookupPreprocessorPathNormalizerTest.kt
+++ b/hoplite-core/src/test/kotlin/com/sksamuel/hoplite/preprocessor/LookupPreprocessorPathNormalizerTest.kt
@@ -1,0 +1,23 @@
+package com.sksamuel.hoplite.preprocessor
+
+import com.sksamuel.hoplite.ConfigLoaderBuilder
+import com.sksamuel.hoplite.addMapSource
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+class LookupPreprocessorPathNormalizerTest : FunSpec({
+
+  // Regression for #503: PathNormalizer lowercases (and strips -/_ from) all map keys, but the
+  // LookupPreprocessor looked up ${...} paths against the normalized tree using the raw, still-cased
+  // key — so a lookup of a mixed-case key could no longer find its (now lowercased) value.
+  test("lookup of a mixed-case key resolves when PathNormalizer is active") {
+    data class Cfg(val fooBar: String, val result: String)
+
+    val cfg = ConfigLoaderBuilder.defaultWithoutPropertySources()
+      .addMapSource(mapOf("fooBar" to "hello", "result" to "\${fooBar}"))
+      .build()
+      .loadConfigOrThrow<Cfg>()
+
+    cfg.result shouldBe "hello"
+  }
+})


### PR DESCRIPTION
Fixes #503.

## Problem

Since 2.8.0, `PathNormalizer` (a default node transformer) lowercases and strips `-`/`_` from every key in the config tree. But `LookupPreprocessor` looks up `${path}` substitutions against that normalized tree using the **raw, still-cased** key. So a lookup of a mixed-case (or dashed) path no longer matches its value:

```kotlin
ConfigLoaderBuilder.defaultWithoutPropertySources()
  .addMapSource(mapOf("fooBar" to "hello", "result" to "\${fooBar}"))
  .build()
  .loadConfigOrThrow<Cfg>()
```

`fooBar` is normalized to `foobar` in the tree, but the lookup of `${fooBar}` does an exact-match `atPath("fooBar")`, finds nothing, and the substitution is left unresolved — under the default builder this then fails the load with `Unresolved substitution ${fooBar}`.

This is the regression described in #503 (the lookup needle stays cased while the haystack keys are lowercased).

## Fix

Normalize the lookup key the same way when `PathNormalizer` is present:

```kotlin
val normalizedKey =
  if (context.nodeTransformers.contains(PathNormalizer)) PathNormalizer.transformPathElement(key) else key
node.atPath(normalizedKey)
```

`transformPathElement` only lowercases and strips `-`/`_` — it leaves `.` intact — so it can be applied to the whole dotted path. This mirrors the existing `ConfigParser.prefixedNode`, which already normalizes a prefix the same way before `atPath`. When `PathNormalizer` is not installed, behavior is unchanged.

## Test

Added `LookupPreprocessorPathNormalizerTest`: a lookup of a mixed-case key under the default (preprocessor + PathNormalizer) builder. Fails on `master` (unresolved substitution), passes here. The existing `LookupPreprocessorTest` (lowercase keys) and the full multi-module suite remain green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)