### PR TITLE
Don't discard a scalar when a higher-precedence map shares its key (#592)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,9 @@ case is still accepted), letters, and digits. **Single underscores** now separat
 loaded by default, and takes precedence over other default sources just like the `EnvironmentVariableOverridePropertySource`
 did. To maintain similar behavior, configure it with a filtering `prefix`.
 * Add the ability to load a series of environment variables into arrays/lists via the `_n` syntax.
+* Fix: a scalar value is no longer discarded when a higher-precedence source (e.g. an environment variable such as
+`HOST_X`) contributes a map at the same key. Previously the map overrode the scalar entirely, causing a spurious
+`Missing` error when decoding that key as a scalar. #592
 
 ### 2.8.0
 

--- a/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/internal/cascade.kt
+++ b/hoplite-core/src/main/kotlin/com/sksamuel/hoplite/internal/cascade.kt
@@ -75,8 +75,19 @@ class Cascader(
                 overrides
               )
             }
-            // since the other once is not a map, we override completely with this
-            else -> CascadeResult(a, listOf(OverridePath(a.path, a.pos, b.pos)))
+            // b is a scalar (or other non-map). Rather than discarding b entirely,
+            // fold its value into a's `value` slot, with a's own value taking
+            // precedence. Otherwise a higher-precedence source that turns this key
+            // into a map (e.g. an env var HOST_X making `host` a map) would silently
+            // drop a lower-precedence scalar at the same key, and decoding that key
+            // as a scalar would then fail with "Missing" (gh-592).
+            else -> {
+              val value = cascade(a.value, b)
+              CascadeResult(
+                MapNode(a.map, a.pos, a.path, value.node, a.meta, a.delimiter, a.sourceKey),
+                value.overrides
+              )
+            }
           }
         }
       }

--- a/hoplite-core/src/test/kotlin/com/sksamuel/hoplite/CascadeTest.kt
+++ b/hoplite-core/src/test/kotlin/com/sksamuel/hoplite/CascadeTest.kt
@@ -177,6 +177,23 @@ class CascadeTest : FunSpec({
     )
   }
 
+  // gh-592: a higher-precedence map sharing a key with a lower-precedence scalar must not
+  // discard the scalar. The merged node keeps the map's children AND carries the scalar
+  // through as its `value`, so the key still decodes as a scalar.
+  test("CascadeMode.Merge must preserve a scalar when a higher-precedence map shares the key") {
+    val map = MapNode(
+      mapOf("foo" to StringNode("bar", Pos.NoPos, DotPath("host", "foo"))),
+      Pos.NoPos,
+      DotPath("host"),
+    )
+    val scalar = StringNode("0.0.0.0", Pos.NoPos, DotPath("host"))
+
+    // a (the map) is the higher-precedence node; b (the scalar) must not be dropped.
+    val merged = Cascader(CascadeMode.Merge, false).cascade(map, scalar).node as MapNode
+    merged.value shouldBe scalar
+    merged["foo"] shouldBe StringNode("bar", Pos.NoPos, DotPath("host", "foo"))
+  }
+
   test("CascadeMode.error should error if overrides present") {
     shouldThrowAny {
       ConfigLoaderBuilder.default()

--- a/hoplite-core/src/test/kotlin/com/sksamuel/hoplite/Issue592Test.kt
+++ b/hoplite-core/src/test/kotlin/com/sksamuel/hoplite/Issue592Test.kt
@@ -1,0 +1,38 @@
+package com.sksamuel.hoplite
+
+import com.sksamuel.hoplite.sources.EnvironmentVariablesPropertySource
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+data class Issue592DatabaseConfig(val host: String)
+data class Issue592Config(val host: String, val database: Issue592DatabaseConfig)
+
+class Issue592Test : FunSpec({
+
+  // gh-592: an environment variable such as HOST_FOO makes the env property source expose
+  // `host` as a map. Being higher precedence than the file, that map used to completely
+  // override the file's scalar `host`, discarding its value — so decoding `host: String`
+  // failed with "Missing String from config", even though the file clearly defined it.
+  // A nested `database.host` was unaffected, and renaming the root key made it work, which
+  // is exactly what the reporter observed.
+  test("a file scalar is not discarded when an env var turns the same key into a map") {
+    val config = ConfigLoaderBuilder.defaultWithoutPropertySources()
+      // higher precedence: turns `host` into a map { foo = bar }
+      .addPropertySource(EnvironmentVariablesPropertySource(environmentVariableMap = { mapOf("HOST_FOO" to "bar") }))
+      // lower precedence: defines `host` and `database.host` as scalars
+      .addPropertySource(
+        PropertySource.string(
+          """
+          host=0.0.0.0
+          database.host=0.0.0.0
+          """.trimIndent(),
+          "props",
+        )
+      )
+      .build()
+      .loadConfigOrThrow<Issue592Config>()
+
+    config.host shouldBe "0.0.0.0"
+    config.database.host shouldBe "0.0.0.0"
+  }
+})


### PR DESCRIPTION
Fixes #592.

## Diagnosis

The reporter's *exact* repro (a `Config(host, database)` with a `default.toml` defining root `host` and `database.host`) **passes** on `master` when loaded from the file alone — so the trigger isn't in the config file. The trigger is a **higher-precedence source contributing a map where a lower-precedence source has a scalar**, most commonly the environment variable source (loaded by default and takes precedence since 3.0.0).

Their three observations all fall out of exactly this collision:

| Observation | Explanation |
|---|---|
| root `host` → `Missing String` | an env var `HOST_<sub>` makes the env source expose `host` as a **map**, which overrides the file's scalar |
| renaming root `host` → `foo` fixes it | no `FOO_<sub>` env var exists, so no collision at that key |
| nested `database.host` works | no colliding `DATABASE_HOST` map (or it merges cleanly) |

## Root cause

In `Cascader.cascade`, when the higher-precedence node `a` is a `MapNode` and the lower `b` is a scalar, the merge returned `a` and dropped `b` entirely:

```kotlin
// since the other once is not a map, we override completely with this
else -> CascadeResult(a, listOf(OverridePath(a.path, a.pos, b.pos)))
```

If `a`'s own `value` is `Undefined` (an env var like `HOST_X` only contributes `host.x`, not `host`), the merged `host` node has no scalar value, so `StringDecoder` reports `Missing`.

## Fix

Fold the scalar into the map node's `value` slot — mirroring the existing two-`MapNode` merge which already does `cascade(a.value, b.value)` — with the map's own value taking precedence. The key decodes as a scalar again, and the map's children are preserved. The fix is at the cascade layer, so it covers every property source (sysprops, XDG, user-settings), not just env vars.

## Tests

- `Issue592Test` — integration test reproducing the env-map-over-file-scalar collision via `ConfigLoaderBuilder`.
- `CascadeTest` — a direct `Cascader` unit test asserting the scalar survives.

Both **fail on `master`** (verified by reverting just `cascade.kt`: the merged value comes back `Undefined`) and pass with the fix. Full `hoplite-core`, `hoplite-toml`, `hoplite-yaml`, `hoplite-json` and `hoplite-hocon` suites are green.

## Notes for review

- **`CascadeMode.Error`:** when the map's own `value` is `Undefined`, the scalar now merges in without recording an override, so this map-over-scalar case is no longer flagged as a conflict in Error mode. That seems more correct (it's a merge, not an override of the same value), and no existing test changes.
- **Scope:** I fixed only the reported direction (map over scalar). The reverse (scalar over map) already keeps the scalar and decodes fine — no `Missing` — so it isn't the reported regression and I left it to limit behavior change.